### PR TITLE
Fix misspell of "Definition" and "definition"

### DIFF
--- a/docs/linux/concepts/pinning.md
+++ b/docs/linux/concepts/pinning.md
@@ -16,8 +16,8 @@ Pins can be removed by using the `rm` cli tool or `unlink` syscall. Pins are eph
 
 Most loader libraries will offer a API for pinning and opening resources from pins. This is usually an action that needs to be explicitly taken. For BTF style maps, however, there is a property called `pinning` which is set to the macro value `LIBBPF_PIN_BY_NAME`/`1` then most loader libraries will attempt to pin the map by default (sometimes given a path to a directory). If a pin already exists, the library will open the pin instead of creating a new map. If no pin exists, the library creates a new map and pins it, using the name of the map as filename.
 
-Example of a map defintion with `pinning`:
-```c
+Example of a map definition with `pinning`:
+:``c
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(max_entries, 1);

--- a/docs/linux/concepts/pinning.md
+++ b/docs/linux/concepts/pinning.md
@@ -17,7 +17,7 @@ Pins can be removed by using the `rm` cli tool or `unlink` syscall. Pins are eph
 Most loader libraries will offer a API for pinning and opening resources from pins. This is usually an action that needs to be explicitly taken. For BTF style maps, however, there is a property called `pinning` which is set to the macro value `LIBBPF_PIN_BY_NAME`/`1` then most loader libraries will attempt to pin the map by default (sometimes given a path to a directory). If a pin already exists, the library will open the pin instead of creating a new map. If no pin exists, the library creates a new map and pins it, using the name of the map as filename.
 
 Example of a map definition with `pinning`:
-:```c
+```c
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(max_entries, 1);

--- a/docs/linux/concepts/pinning.md
+++ b/docs/linux/concepts/pinning.md
@@ -17,7 +17,7 @@ Pins can be removed by using the `rm` cli tool or `unlink` syscall. Pins are eph
 Most loader libraries will offer a API for pinning and opening resources from pins. This is usually an action that needs to be explicitly taken. For BTF style maps, however, there is a property called `pinning` which is set to the macro value `LIBBPF_PIN_BY_NAME`/`1` then most loader libraries will attempt to pin the map by default (sometimes given a path to a directory). If a pin already exists, the library will open the pin instead of creating a new map. If no pin exists, the library creates a new map and pins it, using the name of the map as filename.
 
 Example of a map definition with `pinning`:
-:``c
+:```c
 struct {
 	__uint(type, BPF_MAP_TYPE_ARRAY);
 	__uint(max_entries, 1);

--- a/docs/linux/helper-function/bpf_bind.md
+++ b/docs/linux/helper-function/bpf_bind.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.17](https://github.com/torvalds/linux/commit/d74bad4e74ee373787a9ae24197c17b7cdc428d5)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_bprm_opts_set.md
+++ b/docs/linux/helper-function/bpf_bprm_opts_set.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.11](https://github.com/torvalds/linux/commit/3f6719c7b62f0327c9091e26d0da10e65668229e)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_btf_find_by_name_kind.md
+++ b/docs/linux/helper-function/bpf_btf_find_by_name_kind.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.14](https://github.com/torvalds/linux/commit/3d78417b60fba249cc555468cb72d96f5cde2964)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_cgrp_storage_delete.md
+++ b/docs/linux/helper-function/bpf_cgrp_storage_delete.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v6.2](https://github.com/torvalds/linux/commit/c4bcfb38a95edb1021a53f2d0356a78120ecfbe4)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_cgrp_storage_get.md
+++ b/docs/linux/helper-function/bpf_cgrp_storage_get.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v6.2](https://github.com/torvalds/linux/commit/c4bcfb38a95edb1021a53f2d0356a78120ecfbe4)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_check_mtu.md
+++ b/docs/linux/helper-function/bpf_check_mtu.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.12](https://github.com/torvalds/linux/commit/34b2021cc61642d61c3cf943d9e71925b827941b)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_clone_redirect.md
+++ b/docs/linux/helper-function/bpf_clone_redirect.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.2](https://github.com/torvalds/linux/commit/3896d655f4d491c67d669a15f275a39f713410f8)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_copy_from_user.md
+++ b/docs/linux/helper-function/bpf_copy_from_user.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/1e6c62a8821557720a9b2ea9617359b264f2f67c)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_copy_from_user_task.md
+++ b/docs/linux/helper-function/bpf_copy_from_user_task.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.18](https://github.com/torvalds/linux/commit/376040e47334c6dc6a939a32197acceb00fe4acf)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_csum_diff.md
+++ b/docs/linux/helper-function/bpf_csum_diff.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.6](https://github.com/torvalds/linux/commit/7d672345ed295b1356a5d9f7111da1d1d7d65867)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_csum_level.md
+++ b/docs/linux/helper-function/bpf_csum_level.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.8](https://github.com/torvalds/linux/commit/7cdec54f9713256bb170873a1fc5c75c9127c9d2)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_csum_update.md
+++ b/docs/linux/helper-function/bpf_csum_update.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.9](https://github.com/torvalds/linux/commit/36bbef52c7eb646ed6247055a2acd3851e317857)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_current_task_under_cgroup.md
+++ b/docs/linux/helper-function/bpf_current_task_under_cgroup.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.9](https://github.com/torvalds/linux/commit/60d20f9195b260bdf0ac10c275ae9f6016f9c069)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_d_path.md
+++ b/docs/linux/helper-function/bpf_d_path.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/6e22ab9da79343532cd3cde39df25e5a5478c692)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_dynptr_data.md
+++ b/docs/linux/helper-function/bpf_dynptr_data.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/34d4ef5775f776ec4b0d53a02d588bf3195cada6)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_dynptr_from_mem.md
+++ b/docs/linux/helper-function/bpf_dynptr_from_mem.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/263ae152e96253f40c2c276faad8629e096b3bad)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_dynptr_read.md
+++ b/docs/linux/helper-function/bpf_dynptr_read.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/13bbbfbea7598ea9f8d9c3d73bf053bb57f9c4b2)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_dynptr_write.md
+++ b/docs/linux/helper-function/bpf_dynptr_write.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/13bbbfbea7598ea9f8d9c3d73bf053bb57f9c4b2)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_fib_lookup.md
+++ b/docs/linux/helper-function/bpf_fib_lookup.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/87f5fc7e48dd3175b30dd03b41564e1a8e136323)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_find_vma.md
+++ b/docs/linux/helper-function/bpf_find_vma.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.17](https://github.com/torvalds/linux/commit/7c7e3d31e7856a8260a254f8c71db416f7f9f5a1)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_for_each_map_elem.md
+++ b/docs/linux/helper-function/bpf_for_each_map_elem.md
@@ -6,7 +6,7 @@
 
 For each element in `map`, call `callback_fn` function with `map`, `callback_ctx` and other map-specific parameters.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_attach_cookie.md
+++ b/docs/linux/helper-function/bpf_get_attach_cookie.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.15](https://github.com/torvalds/linux/commit/82e6b1eee6a8875ef4eacfd60711cce6965c6b04)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_branch_snapshot.md
+++ b/docs/linux/helper-function/bpf_get_branch_snapshot.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.16](https://github.com/torvalds/linux/commit/856c02dbce4f8d6a5644083db22c11750aa11481)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_cgroup_classid.md
+++ b/docs/linux/helper-function/bpf_get_cgroup_classid.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.3](https://github.com/torvalds/linux/commit/8d20aabe1c76cccac544d9fcc3ad7823d9e98a2d)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_current_ancestor_cgroup_id.md
+++ b/docs/linux/helper-function/bpf_get_current_ancestor_cgroup_id.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.7](https://github.com/torvalds/linux/commit/0f09abd105da6c37713d2b253730a86cb45e127a)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_current_cgroup_id.md
+++ b/docs/linux/helper-function/bpf_get_current_cgroup_id.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/bf6fa2c893c5237b48569a13fa3c673041430b6c)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_current_comm.md
+++ b/docs/linux/helper-function/bpf_get_current_comm.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.2](https://github.com/torvalds/linux/commit/ffeedafbf0236f03aeb2e8db273b3e5ae5f5bc89)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_current_pid_tgid.md
+++ b/docs/linux/helper-function/bpf_get_current_pid_tgid.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.2](https://github.com/torvalds/linux/commit/ffeedafbf0236f03aeb2e8db273b3e5ae5f5bc89)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_current_task.md
+++ b/docs/linux/helper-function/bpf_get_current_task.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.8](https://github.com/torvalds/linux/commit/606274c5abd8e245add01bc7145a8cbb92b69ba8)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_current_task_btf.md
+++ b/docs/linux/helper-function/bpf_get_current_task_btf.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.11](https://github.com/torvalds/linux/commit/3ca1032ab7ab010eccb107aa515598788f7d93bb)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_current_uid_gid.md
+++ b/docs/linux/helper-function/bpf_get_current_uid_gid.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.2](https://github.com/torvalds/linux/commit/ffeedafbf0236f03aeb2e8db273b3e5ae5f5bc89)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_func_arg.md
+++ b/docs/linux/helper-function/bpf_get_func_arg.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.17](https://github.com/torvalds/linux/commit/f92c1e183604c20ce00eb889315fdaa8f2d9e509)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_func_arg_cnt.md
+++ b/docs/linux/helper-function/bpf_get_func_arg_cnt.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.17](https://github.com/torvalds/linux/commit/f92c1e183604c20ce00eb889315fdaa8f2d9e509)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_func_ip.md
+++ b/docs/linux/helper-function/bpf_get_func_ip.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.15](https://github.com/torvalds/linux/commit/9b99edcae5c80c8fb9f8e7149bae528c9e610a72)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_func_ret.md
+++ b/docs/linux/helper-function/bpf_get_func_ret.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.17](https://github.com/torvalds/linux/commit/f92c1e183604c20ce00eb889315fdaa8f2d9e509)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_hash_recalc.md
+++ b/docs/linux/helper-function/bpf_get_hash_recalc.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.8](https://github.com/torvalds/linux/commit/13c5c240f789bbd2bcacb14a23771491485ae61f)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_listener_sock.md
+++ b/docs/linux/helper-function/bpf_get_listener_sock.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.1](https://github.com/torvalds/linux/commit/dbafd7ddd62369b2f3926ab847cbf8fc40e800b7)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_local_storage.md
+++ b/docs/linux/helper-function/bpf_get_local_storage.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.19](https://github.com/torvalds/linux/commit/cd3394317653837e2eb5c5d0904a8996102af9fc)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_netns_cookie.md
+++ b/docs/linux/helper-function/bpf_get_netns_cookie.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.7](https://github.com/torvalds/linux/commit/f318903c0bf42448b4c884732df2bbb0ef7a2284)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_ns_current_pid_tgid.md
+++ b/docs/linux/helper-function/bpf_get_ns_current_pid_tgid.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.7](https://github.com/torvalds/linux/commit/b4490c5c4e023f09b7d27c9a9d3e7ad7d09ea6bf)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_numa_node_id.md
+++ b/docs/linux/helper-function/bpf_get_numa_node_id.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.10](https://github.com/torvalds/linux/commit/2d0e30c30f84d08dc16f0f2af41f1b8a85f0755e)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_prandom_u32.md
+++ b/docs/linux/helper-function/bpf_get_prandom_u32.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.17](https://github.com/torvalds/linux/commit/df4a37d8b53f9fb9af722b056da5edbd9a531768)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_retval.md
+++ b/docs/linux/helper-function/bpf_get_retval.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.18](https://github.com/torvalds/linux/commit/b44123b4a3dcad4664d3a0f72c011ffd4c9c4d93)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_route_realm.md
+++ b/docs/linux/helper-function/bpf_get_route_realm.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.4](https://github.com/torvalds/linux/commit/c46646d0484f5d08e2bede9b45034ba5b8b489cc)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_smp_processor_id.md
+++ b/docs/linux/helper-function/bpf_get_smp_processor_id.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.1](https://github.com/torvalds/linux/commit/c04167ce2ca0ecaeaafef006cb0d65cf01b68e42)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_socket_cookie.md
+++ b/docs/linux/helper-function/bpf_get_socket_cookie.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.12](https://github.com/torvalds/linux/commit/91b8270f2a4d1d9b268de90451cdca63a70052d6)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_socket_uid.md
+++ b/docs/linux/helper-function/bpf_get_socket_uid.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.12](https://github.com/torvalds/linux/commit/6acc5c2910689fc6ee181bf63085c5efff6a42bd)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_stack.md
+++ b/docs/linux/helper-function/bpf_get_stack.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/c195651e565ae7f41a68acb7d4aa7390ad215de1)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_stackid.md
+++ b/docs/linux/helper-function/bpf_get_stackid.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.6](https://github.com/torvalds/linux/commit/d5a3b1f691865be576c2bffa708549b8cdccda19)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_get_task_stack.md
+++ b/docs/linux/helper-function/bpf_get_task_stack.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.9](https://github.com/torvalds/linux/commit/fa28dcb82a38f8e3993b0fae9106b1a80b59e4f0)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_getsockopt.md
+++ b/docs/linux/helper-function/bpf_getsockopt.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.15](https://github.com/torvalds/linux/commit/cd86d1fd21025fdd6daf23d1288da405e7ad0ec6)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ima_file_hash.md
+++ b/docs/linux/helper-function/bpf_ima_file_hash.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.18](https://github.com/torvalds/linux/commit/174b16946e39ebd369097e0f773536c91a8c1a4c)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ima_inode_hash.md
+++ b/docs/linux/helper-function/bpf_ima_inode_hash.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.11](https://github.com/torvalds/linux/commit/27672f0d280a3f286a410a8db2004f46ace72a17)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_inode_storage_delete.md
+++ b/docs/linux/helper-function/bpf_inode_storage_delete.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/8ea636848aca35b9f97c5b5dee30225cf2dd0fe6)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_inode_storage_get.md
+++ b/docs/linux/helper-function/bpf_inode_storage_get.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/8ea636848aca35b9f97c5b5dee30225cf2dd0fe6)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_jiffies64.md
+++ b/docs/linux/helper-function/bpf_jiffies64.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.6](https://github.com/torvalds/linux/commit/5576b991e9c1a11d2cc21c4b94fc75ec27603896)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_kallsyms_lookup_name.md
+++ b/docs/linux/helper-function/bpf_kallsyms_lookup_name.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.16](https://github.com/torvalds/linux/commit/d6aef08a872b9e23eecc92d0e92393473b13c497)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_kptr_xchg.md
+++ b/docs/linux/helper-function/bpf_kptr_xchg.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/c0a5a21c25f37c9fd7b36072f9968cdff1e4aa13)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ktime_get_boot_ns.md
+++ b/docs/linux/helper-function/bpf_ktime_get_boot_ns.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.8](https://github.com/torvalds/linux/commit/71d19214776e61b33da48f7c1b46e522c7f78221)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ktime_get_coarse_ns.md
+++ b/docs/linux/helper-function/bpf_ktime_get_coarse_ns.md
@@ -3,7 +3,7 @@
 <!-- [FEATURE_TAG](bpf_ktime_get_coarse_ns) -->
 [:octicons-tag-24: v5.11](https://github.com/torvalds/linux/commit/d055126180564a57fe533728a4e93d0cb53d49b3)
 <!-- [/FEATURE_TAG] -->
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ktime_get_ns.md
+++ b/docs/linux/helper-function/bpf_ktime_get_ns.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.1](https://github.com/torvalds/linux/commit/d9847d310ab4003725e6ed1822682e24bd406908)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ktime_get_tai_ns.md
+++ b/docs/linux/helper-function/bpf_ktime_get_tai_ns.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v6.1](https://github.com/torvalds/linux/commit/c8996c98f703b09afe77a1d247dae691c9849dc1)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_l3_csum_replace.md
+++ b/docs/linux/helper-function/bpf_l3_csum_replace.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.1](https://github.com/torvalds/linux/commit/91bc4822c3d61b9bb7ef66d3b77948a4f9177954)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_l4_csum_replace.md
+++ b/docs/linux/helper-function/bpf_l4_csum_replace.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.1](https://github.com/torvalds/linux/commit/91bc4822c3d61b9bb7ef66d3b77948a4f9177954)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_load_hdr_opt.md
+++ b/docs/linux/helper-function/bpf_load_hdr_opt.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/0813a841566f0962a5551be7749b43c45f0022a0)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_loop.md
+++ b/docs/linux/helper-function/bpf_loop.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.17](https://github.com/torvalds/linux/commit/e6f2dd0f80674e9d5960337b3e9c2a242441b326)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_lwt_push_encap.md
+++ b/docs/linux/helper-function/bpf_lwt_push_encap.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/fe94cc290f535709d3c5ebd1e472dfd0aec7ee79)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_lwt_seg6_action.md
+++ b/docs/linux/helper-function/bpf_lwt_seg6_action.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/fe94cc290f535709d3c5ebd1e472dfd0aec7ee79)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_lwt_seg6_adjust_srh.md
+++ b/docs/linux/helper-function/bpf_lwt_seg6_adjust_srh.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/fe94cc290f535709d3c5ebd1e472dfd0aec7ee79)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_lwt_seg6_store_bytes.md
+++ b/docs/linux/helper-function/bpf_lwt_seg6_store_bytes.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/fe94cc290f535709d3c5ebd1e472dfd0aec7ee79)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_map_delete_elem.md
+++ b/docs/linux/helper-function/bpf_map_delete_elem.md
@@ -6,7 +6,7 @@
 
 The delete map element helper call is used to delete values from [maps](../index.md#maps).
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_map_lookup_elem.md
+++ b/docs/linux/helper-function/bpf_map_lookup_elem.md
@@ -6,7 +6,7 @@
 
 The lookup map element helper call is used to read values from [maps](../index.md#maps).
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_map_lookup_percpu_elem.md
+++ b/docs/linux/helper-function/bpf_map_lookup_percpu_elem.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/07343110b293456d30393e89b86c4dee1ac051c8)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_map_peek_elem.md
+++ b/docs/linux/helper-function/bpf_map_peek_elem.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.20](https://github.com/torvalds/linux/commit/f1a2e44a3aeccb3ff18d3ccc0b0203e70b95bd92)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_map_pop_elem.md
+++ b/docs/linux/helper-function/bpf_map_pop_elem.md
@@ -5,7 +5,7 @@
 <!-- [/FEATURE_TAG] -->
 
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_map_push_elem.md
+++ b/docs/linux/helper-function/bpf_map_push_elem.md
@@ -5,7 +5,7 @@
 <!-- [/FEATURE_TAG] -->
 
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_map_update_elem.md
+++ b/docs/linux/helper-function/bpf_map_update_elem.md
@@ -6,7 +6,7 @@
 
 The update map element helper call is used to write values from [maps](../index.md#maps).
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_msg_apply_bytes.md
+++ b/docs/linux/helper-function/bpf_msg_apply_bytes.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.17](https://github.com/torvalds/linux/commit/2a100317c9ebc204a166f16294884fbf9da074ce)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_msg_cork_bytes.md
+++ b/docs/linux/helper-function/bpf_msg_cork_bytes.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.17](https://github.com/torvalds/linux/commit/91843d540a139eb8070bcff8aa10089164436deb)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_msg_pop_data.md
+++ b/docs/linux/helper-function/bpf_msg_pop_data.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.0](https://github.com/torvalds/linux/commit/7246d8ed4dcce23f7509949a77be15fa9f0e3d28)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_msg_pull_data.md
+++ b/docs/linux/helper-function/bpf_msg_pull_data.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.17](https://github.com/torvalds/linux/commit/015632bb30daaaee64e1bcac07570860e0bf3092)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_msg_push_data.md
+++ b/docs/linux/helper-function/bpf_msg_push_data.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.20](https://github.com/torvalds/linux/commit/6fff607e2f14bd7c63c06c464a6f93b8efbabe28)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_msg_redirect_hash.md
+++ b/docs/linux/helper-function/bpf_msg_redirect_hash.md
@@ -6,7 +6,7 @@
 
 The message redirect hash helper is used to redirect a message to a socket referenced by a hash map.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_msg_redirect_map.md
+++ b/docs/linux/helper-function/bpf_msg_redirect_map.md
@@ -6,7 +6,7 @@
 
 The message redirect map helper is used to redirect a message to a socket referenced by a map.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_override_return.md
+++ b/docs/linux/helper-function/bpf_override_return.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.16](https://github.com/torvalds/linux/commit/9802d86585db91655c7d1929a4f6bbe0952ea88e)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_per_cpu_ptr.md
+++ b/docs/linux/helper-function/bpf_per_cpu_ptr.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/eaa6bcb71ef6ed3dc18fc525ee7e293b06b4882b)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_perf_event_output.md
+++ b/docs/linux/helper-function/bpf_perf_event_output.md
@@ -6,7 +6,7 @@
 
 This helper writes a raw `data` blob into a special BPF perf event held by `map` of type [`BPF_MAP_TYPE_PERF_EVENT_ARRAY`](../map-type/BPF_MAP_TYPE_PERF_EVENT_ARRAY.md).
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_perf_event_read.md
+++ b/docs/linux/helper-function/bpf_perf_event_read.md
@@ -6,7 +6,7 @@
 
 This helper reads the value of a perf event counter.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_perf_event_read_value.md
+++ b/docs/linux/helper-function/bpf_perf_event_read_value.md
@@ -6,7 +6,7 @@
 
 This helper function reads the value of a perf event counter, and store it into `buf` of size `buf_size`.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_perf_prog_read_value.md
+++ b/docs/linux/helper-function/bpf_perf_prog_read_value.md
@@ -6,7 +6,7 @@
 
 This helper retrieves the value of an event counter.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_probe_read.md
+++ b/docs/linux/helper-function/bpf_probe_read.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.1](https://github.com/torvalds/linux/commit/2541517c32be2531e0da59dfd7efc1ce844644f5)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_probe_read_kernel.md
+++ b/docs/linux/helper-function/bpf_probe_read_kernel.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.5](https://github.com/torvalds/linux/commit/6ae08ae3dea2cfa03dd3665a3c8475c2d429ef47)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_probe_read_kernel_str.md
+++ b/docs/linux/helper-function/bpf_probe_read_kernel_str.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v6.2](https://github.com/torvalds/linux/commit/c4bcfb38a95edb1021a53f2d0356a78120ecfbe4)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_probe_read_str.md
+++ b/docs/linux/helper-function/bpf_probe_read_str.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.11](https://github.com/torvalds/linux/commit/a5e8c07059d0f0b31737408711d44794928ac218)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_probe_read_user.md
+++ b/docs/linux/helper-function/bpf_probe_read_user.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.5](https://github.com/torvalds/linux/commit/6ae08ae3dea2cfa03dd3665a3c8475c2d429ef47)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_probe_read_user_str.md
+++ b/docs/linux/helper-function/bpf_probe_read_user_str.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.5](https://github.com/torvalds/linux/commit/6ae08ae3dea2cfa03dd3665a3c8475c2d429ef47)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_probe_write_user.md
+++ b/docs/linux/helper-function/bpf_probe_write_user.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.8](https://github.com/torvalds/linux/commit/96ae52279594470622ff0585621a13e96b700600)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_rc_keydown.md
+++ b/docs/linux/helper-function/bpf_rc_keydown.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/f4364dcfc86df7c1ca47b256eaf6b6d0cdd0d936)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_rc_pointer_rel.md
+++ b/docs/linux/helper-function/bpf_rc_pointer_rel.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.0](https://github.com/torvalds/linux/commit/01d3240a04f4c09392e13c77b54d4423ebce2d72)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_rc_repeat.md
+++ b/docs/linux/helper-function/bpf_rc_repeat.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/f4364dcfc86df7c1ca47b256eaf6b6d0cdd0d936)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_read_branch_records.md
+++ b/docs/linux/helper-function/bpf_read_branch_records.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.7](https://github.com/torvalds/linux/commit/fff7b64355eac6e29b50229ad1512315bc04b44e)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_redirect.md
+++ b/docs/linux/helper-function/bpf_redirect.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.4](https://github.com/torvalds/linux/commit/27b29f63058d26c6c1742f1993338280d5a41dc6)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_redirect_map.md
+++ b/docs/linux/helper-function/bpf_redirect_map.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.14](https://github.com/torvalds/linux/commit/546ac1ffb70d25b56c1126940e5ec639c4dd7413)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_redirect_neigh.md
+++ b/docs/linux/helper-function/bpf_redirect_neigh.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/b4ab31414970a7a03a5d55d75083f2c101a30592)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_redirect_peer.md
+++ b/docs/linux/helper-function/bpf_redirect_peer.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/9aa1206e8f48222f35a0c809f33b2f4aaa1e2661)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_reserve_hdr_opt.md
+++ b/docs/linux/helper-function/bpf_reserve_hdr_opt.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/0813a841566f0962a5551be7749b43c45f0022a0)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ringbuf_discard.md
+++ b/docs/linux/helper-function/bpf_ringbuf_discard.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ringbuf_discard_dynptr.md
+++ b/docs/linux/helper-function/bpf_ringbuf_discard_dynptr.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ringbuf_output.md
+++ b/docs/linux/helper-function/bpf_ringbuf_output.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ringbuf_query.md
+++ b/docs/linux/helper-function/bpf_ringbuf_query.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ringbuf_reserve.md
+++ b/docs/linux/helper-function/bpf_ringbuf_reserve.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ringbuf_reserve_dynptr.md
+++ b/docs/linux/helper-function/bpf_ringbuf_reserve_dynptr.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ringbuf_submit.md
+++ b/docs/linux/helper-function/bpf_ringbuf_submit.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_ringbuf_submit_dynptr.md
+++ b/docs/linux/helper-function/bpf_ringbuf_submit_dynptr.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_send_signal.md
+++ b/docs/linux/helper-function/bpf_send_signal.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.3](https://github.com/torvalds/linux/commit/8b401f9ed2441ad9e219953927a842d24ed051fc)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_send_signal_thread.md
+++ b/docs/linux/helper-function/bpf_send_signal_thread.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.6](https://github.com/torvalds/linux/commit/8482941f09067da42f9c3362e15bfb3f3c19d610)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_seq_printf.md
+++ b/docs/linux/helper-function/bpf_seq_printf.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.8](https://github.com/torvalds/linux/commit/492e639f0c222784e2e0f121966375f641c61b15)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_seq_printf_btf.md
+++ b/docs/linux/helper-function/bpf_seq_printf_btf.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/eb411377aed9e27835e77ee0710ee8f4649958f3)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_seq_write.md
+++ b/docs/linux/helper-function/bpf_seq_write.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.8](https://github.com/torvalds/linux/commit/492e639f0c222784e2e0f121966375f641c61b15)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_set_hash.md
+++ b/docs/linux/helper-function/bpf_set_hash.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.13](https://github.com/torvalds/linux/commit/ded092cd73c2c56a394b936f86897f29b2e131c0)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_set_hash_invalid.md
+++ b/docs/linux/helper-function/bpf_set_hash_invalid.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.9](https://github.com/torvalds/linux/commit/7a4b28c6cc9ffac50f791b99cc7e46106436e5d8)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_set_retval.md
+++ b/docs/linux/helper-function/bpf_set_retval.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.18](https://github.com/torvalds/linux/commit/b44123b4a3dcad4664d3a0f72c011ffd4c9c4d93)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_setsockopt.md
+++ b/docs/linux/helper-function/bpf_setsockopt.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.13](https://github.com/torvalds/linux/commit/8c4b4c7e9ff0447995750d9329949fa082520269)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sk_ancestor_cgroup_id.md
+++ b/docs/linux/helper-function/bpf_sk_ancestor_cgroup_id.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.8](https://github.com/torvalds/linux/commit/f307fa2cb4c935f7f1ff0aeb880c7b44fb9a642b)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sk_assign.md
+++ b/docs/linux/helper-function/bpf_sk_assign.md
@@ -6,7 +6,7 @@
 
 This helper function is used to direct incoming traffic to a specific socket, overruling the normal socket selection logic.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sk_cgroup_id.md
+++ b/docs/linux/helper-function/bpf_sk_cgroup_id.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.8](https://github.com/torvalds/linux/commit/f307fa2cb4c935f7f1ff0aeb880c7b44fb9a642b)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sk_fullsock.md
+++ b/docs/linux/helper-function/bpf_sk_fullsock.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.1](https://github.com/torvalds/linux/commit/46f8bc92758c6259bcf945e9216098661c1587cd)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sk_lookup_tcp.md
+++ b/docs/linux/helper-function/bpf_sk_lookup_tcp.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.20](https://github.com/torvalds/linux/commit/6acc9b432e6714d72d7d77ec7c27f6f8358d0c71)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sk_lookup_udp.md
+++ b/docs/linux/helper-function/bpf_sk_lookup_udp.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.20](https://github.com/torvalds/linux/commit/6acc9b432e6714d72d7d77ec7c27f6f8358d0c71)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sk_redirect_hash.md
+++ b/docs/linux/helper-function/bpf_sk_redirect_hash.md
@@ -6,7 +6,7 @@
 
 The message redirect hash helper is used to redirect a message to a socket referenced by a hash map.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sk_redirect_map.md
+++ b/docs/linux/helper-function/bpf_sk_redirect_map.md
@@ -6,7 +6,7 @@
 
 The message redirect map helper is used to redirect a message to a socket referenced by a map.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sk_release.md
+++ b/docs/linux/helper-function/bpf_sk_release.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.20](https://github.com/torvalds/linux/commit/6acc9b432e6714d72d7d77ec7c27f6f8358d0c71)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sk_select_reuseport.md
+++ b/docs/linux/helper-function/bpf_sk_select_reuseport.md
@@ -6,7 +6,7 @@
 
 The socket select reuse port helper select which socket to send an incoming request to when multiple sockets are bound to the same port.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sk_storage_delete.md
+++ b/docs/linux/helper-function/bpf_sk_storage_delete.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.2](https://github.com/torvalds/linux/commit/6ac99e8f23d4b10258406ca0dd7bffca5f31da9d)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sk_storage_get.md
+++ b/docs/linux/helper-function/bpf_sk_storage_get.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.2](https://github.com/torvalds/linux/commit/6ac99e8f23d4b10258406ca0dd7bffca5f31da9d)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_adjust_room.md
+++ b/docs/linux/helper-function/bpf_skb_adjust_room.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.13](https://github.com/torvalds/linux/commit/2be7e212d5419a400d051c84ca9fdd083e5aacac)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_ancestor_cgroup_id.md
+++ b/docs/linux/helper-function/bpf_skb_ancestor_cgroup_id.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.19](https://github.com/torvalds/linux/commit/7723628101aaeb1d723786747529b4ea65c5b5c5)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_cgroup_classid.md
+++ b/docs/linux/helper-function/bpf_skb_cgroup_classid.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/b426ce83baa7dff947fb354118d3133f2953aac8)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_cgroup_id.md
+++ b/docs/linux/helper-function/bpf_skb_cgroup_id.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/cb20b08ead401fd17627a36f035c0bf5bfee5567)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_change_head.md
+++ b/docs/linux/helper-function/bpf_skb_change_head.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.10](https://github.com/torvalds/linux/commit/3a0af8fd61f90920f6fa04e4f1e9a6a73c1b4fd2)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_change_proto.md
+++ b/docs/linux/helper-function/bpf_skb_change_proto.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.8](https://github.com/torvalds/linux/commit/6578171a7ff0c31dc73258f93da7407510abf085)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_change_tail.md
+++ b/docs/linux/helper-function/bpf_skb_change_tail.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.9](https://github.com/torvalds/linux/commit/5293efe62df81908f2e90c9820c7edcc8e61f5e9)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_change_type.md
+++ b/docs/linux/helper-function/bpf_skb_change_type.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.8](https://github.com/torvalds/linux/commit/d2485c4242a826fdf493fd3a27b8b792965b9b9e)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_ecn_set_ce.md
+++ b/docs/linux/helper-function/bpf_skb_ecn_set_ce.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.1](https://github.com/torvalds/linux/commit/f7c917ba11a67632a8452ea99fe132f626a7a2cc)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_get_tunnel_key.md
+++ b/docs/linux/helper-function/bpf_skb_get_tunnel_key.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.3](https://github.com/torvalds/linux/commit/d3aa45ce6b94c65b83971257317867db13e5f492)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_get_tunnel_opt.md
+++ b/docs/linux/helper-function/bpf_skb_get_tunnel_opt.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.6](https://github.com/torvalds/linux/commit/14ca0751c96f8d3d0f52e8ed3b3236f8b34d3460)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_get_xfrm_state.md
+++ b/docs/linux/helper-function/bpf_skb_get_xfrm_state.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/12bed760a78da6e12ac8252fec64d019a9eac523)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_load_bytes.md
+++ b/docs/linux/helper-function/bpf_skb_load_bytes.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.5](https://github.com/torvalds/linux/commit/05c74e5e53f6cb07502c3e6a820f33e2777b6605)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_load_bytes_relative.md
+++ b/docs/linux/helper-function/bpf_skb_load_bytes_relative.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/4e1ec56cdc59746943b2acfab3c171b930187bbe)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_output.md
+++ b/docs/linux/helper-function/bpf_skb_output.md
@@ -6,7 +6,7 @@
 
 This helper writes a raw `data` blob into a special BPF perf event held by `map` of type [`BPF_MAP_TYPE_PERF_EVENT_ARRAY`](../map-type/BPF_MAP_TYPE_PERF_EVENT_ARRAY.md).
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_pull_data.md
+++ b/docs/linux/helper-function/bpf_skb_pull_data.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.9](https://github.com/torvalds/linux/commit/36bbef52c7eb646ed6247055a2acd3851e317857)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_set_tstamp.md
+++ b/docs/linux/helper-function/bpf_skb_set_tstamp.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.18](https://github.com/torvalds/linux/commit/9bb984f28d5bcb917d35d930fcfb89f90f9449fd)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_set_tunnel_key.md
+++ b/docs/linux/helper-function/bpf_skb_set_tunnel_key.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.3](https://github.com/torvalds/linux/commit/d3aa45ce6b94c65b83971257317867db13e5f492)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_set_tunnel_opt.md
+++ b/docs/linux/helper-function/bpf_skb_set_tunnel_opt.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.6](https://github.com/torvalds/linux/commit/14ca0751c96f8d3d0f52e8ed3b3236f8b34d3460)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_store_bytes.md
+++ b/docs/linux/helper-function/bpf_skb_store_bytes.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.1](https://github.com/torvalds/linux/commit/608cd71a9c7c9db76e78a792c5a4101e12fea43f)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_under_cgroup.md
+++ b/docs/linux/helper-function/bpf_skb_under_cgroup.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.8](https://github.com/torvalds/linux/commit/747ea55e4f78fd980350c39570a986b8c1c3e4aa)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_vlan_pop.md
+++ b/docs/linux/helper-function/bpf_skb_vlan_pop.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.3](https://github.com/torvalds/linux/commit/4e10df9a60d96ced321dd2af71da558c6b750078)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skb_vlan_push.md
+++ b/docs/linux/helper-function/bpf_skb_vlan_push.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.3](https://github.com/torvalds/linux/commit/4e10df9a60d96ced321dd2af71da558c6b750078)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skc_lookup_tcp.md
+++ b/docs/linux/helper-function/bpf_skc_lookup_tcp.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.2](https://github.com/torvalds/linux/commit/edbf8c01de5a104a71ed6df2bf6421ceb2836a8e)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skc_to_mptcp_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_mptcp_sock.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/3bc253c2e652cf5f12cd8c00d80d8ec55d67d1a7)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skc_to_tcp6_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_tcp6_sock.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.9](https://github.com/torvalds/linux/commit/af7ec13833619e17f03aa73a785a2f871da6d66b)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skc_to_tcp_request_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_tcp_request_sock.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.9](https://github.com/torvalds/linux/commit/478cfbdf5f13dfe09cfd0b1cbac821f5e27f6108)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skc_to_tcp_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_tcp_sock.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.9](https://github.com/torvalds/linux/commit/478cfbdf5f13dfe09cfd0b1cbac821f5e27f6108)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skc_to_tcp_timewait_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_tcp_timewait_sock.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.9](https://github.com/torvalds/linux/commit/478cfbdf5f13dfe09cfd0b1cbac821f5e27f6108)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skc_to_udp6_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_udp6_sock.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.9](https://github.com/torvalds/linux/commit/0d4fad3e57df2bf61e8ffc8d12a34b1caf9b8835)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_skc_to_unix_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_unix_sock.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.16](https://github.com/torvalds/linux/commit/9eeb3aa33ae005526f672b394c1791578463513f)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_snprintf.md
+++ b/docs/linux/helper-function/bpf_snprintf.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.13](https://github.com/torvalds/linux/commit/7b15523a989b63927c2bb08e9b5b0bbc10b58bef)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_snprintf_btf.md
+++ b/docs/linux/helper-function/bpf_snprintf_btf.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/c4d0bfb45068d853a478b9067a95969b1886a30f)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sock_from_file.md
+++ b/docs/linux/helper-function/bpf_sock_from_file.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.11](https://github.com/torvalds/linux/commit/4f19cab76136e800a3f04d8c9aa4d8e770e3d3d8)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sock_hash_update.md
+++ b/docs/linux/helper-function/bpf_sock_hash_update.md
@@ -6,7 +6,7 @@
 
 Add an entry to, or update a `map` referencing sockets.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sock_map_update.md
+++ b/docs/linux/helper-function/bpf_sock_map_update.md
@@ -6,7 +6,7 @@
 
 Add an entry to, or update a `map` referencing sockets.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sock_ops_cb_flags_set.md
+++ b/docs/linux/helper-function/bpf_sock_ops_cb_flags_set.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.16](https://github.com/torvalds/linux/commit/b13d880721729384757f235166068c315326f4a1)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_spin_lock.md
+++ b/docs/linux/helper-function/bpf_spin_lock.md
@@ -10,7 +10,7 @@ safely update the rest of the fields in that value. The
 spinlock can (and must) later be released with a call to
 [`bpf_spin_unlock`](bpf_spin_unlock.md).
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_spin_unlock.md
+++ b/docs/linux/helper-function/bpf_spin_unlock.md
@@ -6,7 +6,7 @@
 
 Release the `lock` previously locked by a call to `bpf_spin_lock(lock)`.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_store_hdr_opt.md
+++ b/docs/linux/helper-function/bpf_store_hdr_opt.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/0813a841566f0962a5551be7749b43c45f0022a0)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_strncmp.md
+++ b/docs/linux/helper-function/bpf_strncmp.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.17](https://github.com/torvalds/linux/commit/c5fb19937455095573a19ddcbff32e993ed10e35)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_strtol.md
+++ b/docs/linux/helper-function/bpf_strtol.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.2](https://github.com/torvalds/linux/commit/d7a4cb9b6705a89937d12c8158a35a3145dc967a)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_strtoul.md
+++ b/docs/linux/helper-function/bpf_strtoul.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.2](https://github.com/torvalds/linux/commit/d7a4cb9b6705a89937d12c8158a35a3145dc967a)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sys_bpf.md
+++ b/docs/linux/helper-function/bpf_sys_bpf.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.14](https://github.com/torvalds/linux/commit/79a7f8bdb159d9914b58740f3d31d602a6e4aca8)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sys_close.md
+++ b/docs/linux/helper-function/bpf_sys_close.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.14](https://github.com/torvalds/linux/commit/3abea089246f76c1517b054ddb5946f3f1dbd2c0)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sysctl_get_current_value.md
+++ b/docs/linux/helper-function/bpf_sysctl_get_current_value.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.2](https://github.com/torvalds/linux/commit/1d11b3016cec4ed9770b98e82a61708c8f4926e7)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sysctl_get_name.md
+++ b/docs/linux/helper-function/bpf_sysctl_get_name.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.2](https://github.com/torvalds/linux/commit/808649fb787d918a48a360a668ee4ee9023f0c11)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sysctl_get_new_value.md
+++ b/docs/linux/helper-function/bpf_sysctl_get_new_value.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.2](https://github.com/torvalds/linux/commit/4e63acdff864654cee0ac5aaeda3913798ee78f6)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_sysctl_set_new_value.md
+++ b/docs/linux/helper-function/bpf_sysctl_set_new_value.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.2](https://github.com/torvalds/linux/commit/4e63acdff864654cee0ac5aaeda3913798ee78f6)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_tail_call.md
+++ b/docs/linux/helper-function/bpf_tail_call.md
@@ -6,7 +6,7 @@
 
 This special helper is used to trigger a "tail call", or in other words, to jump into another eBPF program.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_task_pt_regs.md
+++ b/docs/linux/helper-function/bpf_task_pt_regs.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.15](https://github.com/torvalds/linux/commit/dd6e10fbd9fb86a571d925602c8a24bb4d09a2a7)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_task_storage_delete.md
+++ b/docs/linux/helper-function/bpf_task_storage_delete.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.11](https://github.com/torvalds/linux/commit/4cf1bc1f10452065a29d576fc5693fc4fab5b919)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_task_storage_get.md
+++ b/docs/linux/helper-function/bpf_task_storage_get.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.11](https://github.com/torvalds/linux/commit/4cf1bc1f10452065a29d576fc5693fc4fab5b919)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_tcp_check_syncookie.md
+++ b/docs/linux/helper-function/bpf_tcp_check_syncookie.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.2](https://github.com/torvalds/linux/commit/399040847084a69f345e0a52fd62f04654e0fce3)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_tcp_gen_syncookie.md
+++ b/docs/linux/helper-function/bpf_tcp_gen_syncookie.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.4](https://github.com/torvalds/linux/commit/70d66244317e958092e9c971b08dd5b7fd29d9cb)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_tcp_raw_check_syncookie_ipv4.md
+++ b/docs/linux/helper-function/bpf_tcp_raw_check_syncookie_ipv4.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v6.0](https://github.com/torvalds/linux/commit/33bf9885040c399cf6a95bd33216644126728e14)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_tcp_raw_check_syncookie_ipv6.md
+++ b/docs/linux/helper-function/bpf_tcp_raw_check_syncookie_ipv6.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v6.0](https://github.com/torvalds/linux/commit/33bf9885040c399cf6a95bd33216644126728e14)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_tcp_raw_gen_syncookie_ipv4.md
+++ b/docs/linux/helper-function/bpf_tcp_raw_gen_syncookie_ipv4.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v6.0](https://github.com/torvalds/linux/commit/33bf9885040c399cf6a95bd33216644126728e14)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_tcp_raw_gen_syncookie_ipv6.md
+++ b/docs/linux/helper-function/bpf_tcp_raw_gen_syncookie_ipv6.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v6.0](https://github.com/torvalds/linux/commit/33bf9885040c399cf6a95bd33216644126728e14)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_tcp_send_ack.md
+++ b/docs/linux/helper-function/bpf_tcp_send_ack.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.6](https://github.com/torvalds/linux/commit/206057fe020ac5c037d5e2dd6562a9bd216ec765)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_tcp_sock.md
+++ b/docs/linux/helper-function/bpf_tcp_sock.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.1](https://github.com/torvalds/linux/commit/655a51e536c09d15ffa3603b1b6fce2b45b85a1f)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_this_cpu_ptr.md
+++ b/docs/linux/helper-function/bpf_this_cpu_ptr.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.10](https://github.com/torvalds/linux/commit/63d9b80dcf2c67bc5ade61cbbaa09d7af21f43f1)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_timer_cancel.md
+++ b/docs/linux/helper-function/bpf_timer_cancel.md
@@ -6,7 +6,7 @@
 
 This helper cancels a pending [timer](../ebpf-concepts/timers.md).
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_timer_init.md
+++ b/docs/linux/helper-function/bpf_timer_init.md
@@ -6,7 +6,7 @@
 
 This helper initializes a [timer](../ebpf-concepts/timers.md).
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_timer_set_callback.md
+++ b/docs/linux/helper-function/bpf_timer_set_callback.md
@@ -6,7 +6,7 @@
 
 This helper sets the callback function for a [timer](../ebpf-concepts/timers.md).
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_timer_start.md
+++ b/docs/linux/helper-function/bpf_timer_start.md
@@ -6,7 +6,7 @@
 
 This helper starts a [timer](../ebpf-concepts/timers.md).
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_trace_printk.md
+++ b/docs/linux/helper-function/bpf_trace_printk.md
@@ -6,7 +6,7 @@
 
 This helper prints messages to the trace log of the kernel.
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_trace_vprintk.md
+++ b/docs/linux/helper-function/bpf_trace_vprintk.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.16](https://github.com/torvalds/linux/commit/10aceb629e198429c849d5e995c3bb1ba7a9aaa3)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_user_ringbuf_drain.md
+++ b/docs/linux/helper-function/bpf_user_ringbuf_drain.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v6.1](https://github.com/torvalds/linux/commit/20571567384428dfc9fe5cf9f2e942e1df13c2dd)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_xdp_adjust_head.md
+++ b/docs/linux/helper-function/bpf_xdp_adjust_head.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.10](https://github.com/torvalds/linux/commit/17bedab2723145d17b14084430743549e6943d03)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_xdp_adjust_meta.md
+++ b/docs/linux/helper-function/bpf_xdp_adjust_meta.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.15](https://github.com/torvalds/linux/commit/de8f3a83b0a0fddb2cf56e7a718127e9619ea3da)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_xdp_adjust_tail.md
+++ b/docs/linux/helper-function/bpf_xdp_adjust_tail.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/b32cc5b9a346319c171e3ad905e0cddda032b5eb)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_xdp_get_buff_len.md
+++ b/docs/linux/helper-function/bpf_xdp_get_buff_len.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.18](https://github.com/torvalds/linux/commit/0165cc817075cf701e4289838f1d925ff1911b3e)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_xdp_load_bytes.md
+++ b/docs/linux/helper-function/bpf_xdp_load_bytes.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.18](https://github.com/torvalds/linux/commit/3f364222d032eea6b245780e845ad213dab28cdd)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_xdp_output.md
+++ b/docs/linux/helper-function/bpf_xdp_output.md
@@ -6,7 +6,7 @@
 
 This helper writes a raw `data` blob into a special BPF perf event held by `map` of type [`BPF_MAP_TYPE_PERF_EVENT_ARRAY`](../map-type/BPF_MAP_TYPE_PERF_EVENT_ARRAY.md).
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 

--- a/docs/linux/helper-function/bpf_xdp_store_bytes.md
+++ b/docs/linux/helper-function/bpf_xdp_store_bytes.md
@@ -4,7 +4,7 @@
 [:octicons-tag-24: v5.18](https://github.com/torvalds/linux/commit/3f364222d032eea6b245780e845ad213dab28cdd)
 <!-- [/FEATURE_TAG] -->
 
-## Defintion
+## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 


### PR DESCRIPTION
This PR fixes a single typo (in both lower and uppercase) across multiple files. I've ran the entire repo through `aspell`, as well as a manual check via vscode and couldn't find any other relevant typos. There is however a huge list of technical terms and abbrevs which are outside the scope of any English dictionary, so it's possible that I've missed something.