### PR TITLE
Remove the `- eBPF docs` suffix from titles

### DIFF
--- a/docs/linux/concepts/af_xdp.md
+++ b/docs/linux/concepts/af_xdp.md
@@ -1,5 +1,5 @@
 ---
-title: "AF_XDP - eBPF Docs"
+title: "AF_XDP"
 description: "This page explains the concept of AF_XDP in depth, AF_XDP being a special socket type which in combination with an XDP program can perform full or partial kernel bypass. Bypassing the kernel network stack can increase performance in certain use cases. A socket created under the AF_XDP address family is also referred to as a XSK (XDP SocKet)."
 ---
 # AF_XDP

--- a/docs/linux/concepts/concurrency.md
+++ b/docs/linux/concepts/concurrency.md
@@ -1,5 +1,5 @@
 ---
-title: "Concurrency - eBPF Docs"
+title: "Concurrency"
 description: "This page explains how to deal with concurrency in eBPF programs. It explains multiple methods to deal with concurrency, their pros and cons, and when to use them."
 ---
 # Concurrency

--- a/docs/linux/concepts/loops.md
+++ b/docs/linux/concepts/loops.md
@@ -1,5 +1,5 @@
 ---
-title: "Loops - eBPF Docs"
+title: "Loops"
 description: "This page explains the limits of loops in eBPF. It explains different methods of looping and their pros, cons, and when you can use them."
 ---
 # Loops in BPF

--- a/docs/linux/concepts/maps.md
+++ b/docs/linux/concepts/maps.md
@@ -1,5 +1,5 @@
 ---
-title: "Maps - eBPF Docs"
+title: "Maps"
 description: "This page explains the concept of eBPF maps. It goes into depth about how to define, create, and use maps in eBPF programs."
 ---
 # Maps

--- a/docs/linux/concepts/pinning.md
+++ b/docs/linux/concepts/pinning.md
@@ -1,5 +1,5 @@
 ---
-title: "Pinning - eBPF Docs"
+title: "Pinning"
 description: "This page explains the concept of pinning in eBPF. It explains what pinning is, how to use it, and when to use it."
 ---
 # Pinning

--- a/docs/linux/concepts/resource-limit.md
+++ b/docs/linux/concepts/resource-limit.md
@@ -1,5 +1,5 @@
 ---
-title: "Resource limits - eBPF Docs"
+title: "Resource limits"
 description: "This page explains the concept of resource limits in eBPF. It explains what resource limits are and how resource limits work."
 ---
 # Resource limits

--- a/docs/linux/concepts/tail-calls.md
+++ b/docs/linux/concepts/tail-calls.md
@@ -1,5 +1,5 @@
 ---
-title: "Tail calls - eBPF Docs"
+title: "Tail calls"
 description: "This page explains the concept of tail calls in eBPF. It explains what tail calls are, how to use them, and when to use them."
 ---
 # Tail calls

--- a/docs/linux/concepts/timers.md
+++ b/docs/linux/concepts/timers.md
@@ -1,5 +1,5 @@
 ---
-title: "Timers - eBPF Docs"
+title: "Timers"
 description: "This page explains the concept of timers in eBPF. It explains what timers are, how to use them, and when to use them."
 ---
 # eBPF timers

--- a/docs/linux/concepts/verifier.md
+++ b/docs/linux/concepts/verifier.md
@@ -1,5 +1,5 @@
 ---
-title: "Verifier - eBPF Docs"
+title: "Verifier"
 description: "This page explains the eBPF verifier. It explains what the verifier is, why it exists, and what features it has."
 ---
 # Verifier

--- a/docs/linux/helper-function/bpf_bind.md
+++ b/docs/linux/helper-function/bpf_bind.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_bind' - eBPF Docs"
+title: "Helper Function 'bpf_bind'"
 description: "This page documents the 'bpf_bind' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_bind`

--- a/docs/linux/helper-function/bpf_bprm_opts_set.md
+++ b/docs/linux/helper-function/bpf_bprm_opts_set.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_bprm_opts_set' - eBPF Docs"
+title: "Helper Function 'bpf_bprm_opts_set'"
 description: "This page documents the 'bpf_bprm_opts_set' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_bprm_opts_set`

--- a/docs/linux/helper-function/bpf_btf_find_by_name_kind.md
+++ b/docs/linux/helper-function/bpf_btf_find_by_name_kind.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_btf_find_by_name_kind' - eBPF Docs"
+title: "Helper Function 'bpf_btf_find_by_name_kind'"
 description: "This page documents the 'bpf_btf_find_by_name_kind' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_btf_find_by_name_kind`

--- a/docs/linux/helper-function/bpf_cgrp_storage_delete.md
+++ b/docs/linux/helper-function/bpf_cgrp_storage_delete.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_cgrp_storage_delete' - eBPF Docs"
+title: "Helper Function 'bpf_cgrp_storage_delete'"
 description: "This page documents the 'bpf_cgrp_storage_delete' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_cgrp_storage_delete`

--- a/docs/linux/helper-function/bpf_cgrp_storage_get.md
+++ b/docs/linux/helper-function/bpf_cgrp_storage_get.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_cgrp_storage_get' - eBPF Docs"
+title: "Helper Function 'bpf_cgrp_storage_get'"
 description: "This page documents the 'bpf_cgrp_storage_get' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_cgrp_storage_get`

--- a/docs/linux/helper-function/bpf_check_mtu.md
+++ b/docs/linux/helper-function/bpf_check_mtu.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_check_mtu' - eBPF Docs"
+title: "Helper Function 'bpf_check_mtu'"
 description: "This page documents the 'bpf_check_mtu' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_check_mtu`

--- a/docs/linux/helper-function/bpf_clone_redirect.md
+++ b/docs/linux/helper-function/bpf_clone_redirect.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_clone_redirect' - eBPF Docs"
+title: "Helper Function 'bpf_clone_redirect'"
 description: "This page documents the 'bpf_clone_redirect' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_clone_redirect`

--- a/docs/linux/helper-function/bpf_copy_from_user.md
+++ b/docs/linux/helper-function/bpf_copy_from_user.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_copy_from_user' - eBPF Docs"
+title: "Helper Function 'bpf_copy_from_user'"
 description: "This page documents the 'bpf_copy_from_user' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_copy_from_user`

--- a/docs/linux/helper-function/bpf_copy_from_user_task.md
+++ b/docs/linux/helper-function/bpf_copy_from_user_task.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_copy_from_user_task' - eBPF Docs"
+title: "Helper Function 'bpf_copy_from_user_task'"
 description: "This page documents the 'bpf_copy_from_user_task' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_copy_from_user_task`

--- a/docs/linux/helper-function/bpf_csum_diff.md
+++ b/docs/linux/helper-function/bpf_csum_diff.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_csum_diff' - eBPF Docs"
+title: "Helper Function 'bpf_csum_diff'"
 description: "This page documents the 'bpf_csum_diff' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_csum_diff`

--- a/docs/linux/helper-function/bpf_csum_level.md
+++ b/docs/linux/helper-function/bpf_csum_level.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_csum_level' - eBPF Docs"
+title: "Helper Function 'bpf_csum_level'"
 description: "This page documents the 'bpf_csum_level' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_csum_level`

--- a/docs/linux/helper-function/bpf_csum_update.md
+++ b/docs/linux/helper-function/bpf_csum_update.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_csum_update' - eBPF Docs"
+title: "Helper Function 'bpf_csum_update'"
 description: "This page documents the 'bpf_csum_update' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_csum_update`

--- a/docs/linux/helper-function/bpf_current_task_under_cgroup.md
+++ b/docs/linux/helper-function/bpf_current_task_under_cgroup.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_current_task_under_cgroup' - eBPF Docs"
+title: "Helper Function 'bpf_current_task_under_cgroup'"
 description: "This page documents the 'bpf_current_task_under_cgroup' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_current_task_under_cgroup`

--- a/docs/linux/helper-function/bpf_d_path.md
+++ b/docs/linux/helper-function/bpf_d_path.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_d_path' - eBPF Docs"
+title: "Helper Function 'bpf_d_path'"
 description: "This page documents the 'bpf_d_path' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_d_path`

--- a/docs/linux/helper-function/bpf_dynptr_data.md
+++ b/docs/linux/helper-function/bpf_dynptr_data.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_dynptr_data' - eBPF Docs"
+title: "Helper Function 'bpf_dynptr_data'"
 description: "This page documents the 'bpf_dynptr_data' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_dynptr_data`

--- a/docs/linux/helper-function/bpf_dynptr_from_mem.md
+++ b/docs/linux/helper-function/bpf_dynptr_from_mem.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_dynptr_from_mem' - eBPF Docs"
+title: "Helper Function 'bpf_dynptr_from_mem'"
 description: "This page documents the 'bpf_dynptr_from_mem' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_dynptr_from_mem`

--- a/docs/linux/helper-function/bpf_dynptr_read.md
+++ b/docs/linux/helper-function/bpf_dynptr_read.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_dynptr_read' - eBPF Docs"
+title: "Helper Function 'bpf_dynptr_read'"
 description: "This page documents the 'bpf_dynptr_read' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_dynptr_read`

--- a/docs/linux/helper-function/bpf_dynptr_write.md
+++ b/docs/linux/helper-function/bpf_dynptr_write.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_dynptr_write' - eBPF Docs"
+title: "Helper Function 'bpf_dynptr_write'"
 description: "This page documents the 'bpf_dynptr_write' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_dynptr_write`

--- a/docs/linux/helper-function/bpf_fib_lookup.md
+++ b/docs/linux/helper-function/bpf_fib_lookup.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_fib_lookup' - eBPF Docs"
+title: "Helper Function 'bpf_fib_lookup'"
 description: "This page documents the 'bpf_fib_lookup' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_fib_lookup`

--- a/docs/linux/helper-function/bpf_find_vma.md
+++ b/docs/linux/helper-function/bpf_find_vma.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_find_vma' - eBPF Docs"
+title: "Helper Function 'bpf_find_vma'"
 description: "This page documents the 'bpf_find_vma' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_find_vma`

--- a/docs/linux/helper-function/bpf_for_each_map_elem.md
+++ b/docs/linux/helper-function/bpf_for_each_map_elem.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_for_each_map_elem' - eBPF Docs"
+title: "Helper Function 'bpf_for_each_map_elem'"
 description: "This page documents the 'bpf_for_each_map_elem' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_for_each_map_elem`

--- a/docs/linux/helper-function/bpf_get_attach_cookie.md
+++ b/docs/linux/helper-function/bpf_get_attach_cookie.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_attach_cookie' - eBPF Docs"
+title: "Helper Function 'bpf_get_attach_cookie'"
 description: "This page documents the 'bpf_get_attach_cookie' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_attach_cookie`

--- a/docs/linux/helper-function/bpf_get_branch_snapshot.md
+++ b/docs/linux/helper-function/bpf_get_branch_snapshot.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_branch_snapshot' - eBPF Docs"
+title: "Helper Function 'bpf_get_branch_snapshot'"
 description: "This page documents the 'bpf_get_branch_snapshot' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_branch_snapshot`

--- a/docs/linux/helper-function/bpf_get_cgroup_classid.md
+++ b/docs/linux/helper-function/bpf_get_cgroup_classid.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_cgroup_classid' - eBPF Docs"
+title: "Helper Function 'bpf_get_cgroup_classid'"
 description: "This page documents the 'bpf_get_cgroup_classid' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_cgroup_classid`

--- a/docs/linux/helper-function/bpf_get_current_ancestor_cgroup_id.md
+++ b/docs/linux/helper-function/bpf_get_current_ancestor_cgroup_id.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_current_ancestor_cgroup_id' - eBPF Docs"
+title: "Helper Function 'bpf_get_current_ancestor_cgroup_id'"
 description: "This page documents the 'bpf_get_current_ancestor_cgroup_id' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_current_ancestor_cgroup_id`

--- a/docs/linux/helper-function/bpf_get_current_cgroup_id.md
+++ b/docs/linux/helper-function/bpf_get_current_cgroup_id.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_current_cgroup_id' - eBPF Docs"
+title: "Helper Function 'bpf_get_current_cgroup_id'"
 description: "This page documents the 'bpf_get_current_cgroup_id' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_current_cgroup_id`

--- a/docs/linux/helper-function/bpf_get_current_comm.md
+++ b/docs/linux/helper-function/bpf_get_current_comm.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_current_comm' - eBPF Docs"
+title: "Helper Function 'bpf_get_current_comm'"
 description: "This page documents the 'bpf_get_current_comm' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_current_comm`

--- a/docs/linux/helper-function/bpf_get_current_pid_tgid.md
+++ b/docs/linux/helper-function/bpf_get_current_pid_tgid.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_current_pid_tgid' - eBPF Docs"
+title: "Helper Function 'bpf_get_current_pid_tgid'"
 description: "This page documents the 'bpf_get_current_pid_tgid' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_current_pid_tgid`

--- a/docs/linux/helper-function/bpf_get_current_task.md
+++ b/docs/linux/helper-function/bpf_get_current_task.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_current_task' - eBPF Docs"
+title: "Helper Function 'bpf_get_current_task'"
 description: "This page documents the 'bpf_get_current_task' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_current_task`

--- a/docs/linux/helper-function/bpf_get_current_task_btf.md
+++ b/docs/linux/helper-function/bpf_get_current_task_btf.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_current_task_btf' - eBPF Docs"
+title: "Helper Function 'bpf_get_current_task_btf'"
 description: "This page documents the 'bpf_get_current_task_btf' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_current_task_btf`

--- a/docs/linux/helper-function/bpf_get_current_uid_gid.md
+++ b/docs/linux/helper-function/bpf_get_current_uid_gid.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_current_uid_gid' - eBPF Docs"
+title: "Helper Function 'bpf_get_current_uid_gid'"
 description: "This page documents the 'bpf_get_current_uid_gid' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_current_uid_gid`

--- a/docs/linux/helper-function/bpf_get_func_arg.md
+++ b/docs/linux/helper-function/bpf_get_func_arg.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_func_arg' - eBPF Docs"
+title: "Helper Function 'bpf_get_func_arg'"
 description: "This page documents the 'bpf_get_func_arg' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_func_arg`

--- a/docs/linux/helper-function/bpf_get_func_arg_cnt.md
+++ b/docs/linux/helper-function/bpf_get_func_arg_cnt.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_func_arg_cnt' - eBPF Docs"
+title: "Helper Function 'bpf_get_func_arg_cnt'"
 description: "This page documents the 'bpf_get_func_arg_cnt' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_func_arg_cnt`

--- a/docs/linux/helper-function/bpf_get_func_ip.md
+++ b/docs/linux/helper-function/bpf_get_func_ip.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_func_ip' - eBPF Docs"
+title: "Helper Function 'bpf_get_func_ip'"
 description: "This page documents the 'bpf_get_func_ip' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_func_ip`

--- a/docs/linux/helper-function/bpf_get_func_ret.md
+++ b/docs/linux/helper-function/bpf_get_func_ret.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_func_ret' - eBPF Docs"
+title: "Helper Function 'bpf_get_func_ret'"
 description: "This page documents the 'bpf_get_func_ret' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_func_ret`

--- a/docs/linux/helper-function/bpf_get_hash_recalc.md
+++ b/docs/linux/helper-function/bpf_get_hash_recalc.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_hash_recalc' - eBPF Docs"
+title: "Helper Function 'bpf_get_hash_recalc'"
 description: "This page documents the 'bpf_get_hash_recalc' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_hash_recalc`

--- a/docs/linux/helper-function/bpf_get_listener_sock.md
+++ b/docs/linux/helper-function/bpf_get_listener_sock.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_listener_sock' - eBPF Docs"
+title: "Helper Function 'bpf_get_listener_sock'"
 description: "This page documents the 'bpf_get_listener_sock' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_listener_sock`

--- a/docs/linux/helper-function/bpf_get_local_storage.md
+++ b/docs/linux/helper-function/bpf_get_local_storage.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_local_storage' - eBPF Docs"
+title: "Helper Function 'bpf_get_local_storage'"
 description: "This page documents the 'bpf_get_local_storage' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_local_storage`

--- a/docs/linux/helper-function/bpf_get_netns_cookie.md
+++ b/docs/linux/helper-function/bpf_get_netns_cookie.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_netns_cookie' - eBPF Docs"
+title: "Helper Function 'bpf_get_netns_cookie'"
 description: "This page documents the 'bpf_get_netns_cookie' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_netns_cookie`

--- a/docs/linux/helper-function/bpf_get_ns_current_pid_tgid.md
+++ b/docs/linux/helper-function/bpf_get_ns_current_pid_tgid.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_ns_current_pid_tgid' - eBPF Docs"
+title: "Helper Function 'bpf_get_ns_current_pid_tgid'"
 description: "This page documents the 'bpf_get_ns_current_pid_tgid' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_ns_current_pid_tgid`

--- a/docs/linux/helper-function/bpf_get_numa_node_id.md
+++ b/docs/linux/helper-function/bpf_get_numa_node_id.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_numa_node_id' - eBPF Docs"
+title: "Helper Function 'bpf_get_numa_node_id'"
 description: "This page documents the 'bpf_get_numa_node_id' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_numa_node_id`

--- a/docs/linux/helper-function/bpf_get_prandom_u32.md
+++ b/docs/linux/helper-function/bpf_get_prandom_u32.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_prandom_u32' - eBPF Docs"
+title: "Helper Function 'bpf_get_prandom_u32'"
 description: "This page documents the 'bpf_get_prandom_u32' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_prandom_u32`

--- a/docs/linux/helper-function/bpf_get_retval.md
+++ b/docs/linux/helper-function/bpf_get_retval.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_retval' - eBPF Docs"
+title: "Helper Function 'bpf_get_retval'"
 description: "This page documents the 'bpf_get_retval' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_retval`

--- a/docs/linux/helper-function/bpf_get_route_realm.md
+++ b/docs/linux/helper-function/bpf_get_route_realm.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_route_realm' - eBPF Docs"
+title: "Helper Function 'bpf_get_route_realm'"
 description: "This page documents the 'bpf_get_route_realm' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_route_realm`

--- a/docs/linux/helper-function/bpf_get_smp_processor_id.md
+++ b/docs/linux/helper-function/bpf_get_smp_processor_id.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_smp_processor_id' - eBPF Docs"
+title: "Helper Function 'bpf_get_smp_processor_id'"
 description: "This page documents the 'bpf_get_smp_processor_id' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_smp_processor_id`

--- a/docs/linux/helper-function/bpf_get_socket_cookie.md
+++ b/docs/linux/helper-function/bpf_get_socket_cookie.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_socket_cookie' - eBPF Docs"
+title: "Helper Function 'bpf_get_socket_cookie'"
 description: "This page documents the 'bpf_get_socket_cookie' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_socket_cookie`

--- a/docs/linux/helper-function/bpf_get_socket_uid.md
+++ b/docs/linux/helper-function/bpf_get_socket_uid.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_socket_uid' - eBPF Docs"
+title: "Helper Function 'bpf_get_socket_uid'"
 description: "This page documents the 'bpf_get_socket_uid' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_socket_uid`

--- a/docs/linux/helper-function/bpf_get_stack.md
+++ b/docs/linux/helper-function/bpf_get_stack.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_stack' - eBPF Docs"
+title: "Helper Function 'bpf_get_stack'"
 description: "This page documents the 'bpf_get_stack' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_stack`

--- a/docs/linux/helper-function/bpf_get_stackid.md
+++ b/docs/linux/helper-function/bpf_get_stackid.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_stackid' - eBPF Docs"
+title: "Helper Function 'bpf_get_stackid'"
 description: "This page documents the 'bpf_get_stackid' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_stackid`

--- a/docs/linux/helper-function/bpf_get_task_stack.md
+++ b/docs/linux/helper-function/bpf_get_task_stack.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_get_task_stack' - eBPF Docs"
+title: "Helper Function 'bpf_get_task_stack'"
 description: "This page documents the 'bpf_get_task_stack' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_get_task_stack`

--- a/docs/linux/helper-function/bpf_getsockopt.md
+++ b/docs/linux/helper-function/bpf_getsockopt.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_getsockopt' - eBPF Docs"
+title: "Helper Function 'bpf_getsockopt'"
 description: "This page documents the 'bpf_getsockopt' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_getsockopt`

--- a/docs/linux/helper-function/bpf_ima_file_hash.md
+++ b/docs/linux/helper-function/bpf_ima_file_hash.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ima_file_hash' - eBPF Docs"
+title: "Helper Function 'bpf_ima_file_hash'"
 description: "This page documents the 'bpf_ima_file_hash' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ima_file_hash`

--- a/docs/linux/helper-function/bpf_ima_inode_hash.md
+++ b/docs/linux/helper-function/bpf_ima_inode_hash.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ima_inode_hash' - eBPF Docs"
+title: "Helper Function 'bpf_ima_inode_hash'"
 description: "This page documents the 'bpf_ima_inode_hash' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ima_inode_hash`

--- a/docs/linux/helper-function/bpf_inode_storage_delete.md
+++ b/docs/linux/helper-function/bpf_inode_storage_delete.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_inode_storage_delete' - eBPF Docs"
+title: "Helper Function 'bpf_inode_storage_delete'"
 description: "This page documents the 'bpf_inode_storage_delete' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_inode_storage_delete`

--- a/docs/linux/helper-function/bpf_inode_storage_get.md
+++ b/docs/linux/helper-function/bpf_inode_storage_get.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_inode_storage_get' - eBPF Docs"
+title: "Helper Function 'bpf_inode_storage_get'"
 description: "This page documents the 'bpf_inode_storage_get' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_inode_storage_get`

--- a/docs/linux/helper-function/bpf_jiffies64.md
+++ b/docs/linux/helper-function/bpf_jiffies64.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_jiffies64' - eBPF Docs"
+title: "Helper Function 'bpf_jiffies64'"
 description: "This page documents the 'bpf_jiffies64' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_jiffies64`

--- a/docs/linux/helper-function/bpf_kallsyms_lookup_name.md
+++ b/docs/linux/helper-function/bpf_kallsyms_lookup_name.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_kallsyms_lookup_name' - eBPF Docs"
+title: "Helper Function 'bpf_kallsyms_lookup_name'"
 description: "This page documents the 'bpf_kallsyms_lookup_name' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_kallsyms_lookup_name`

--- a/docs/linux/helper-function/bpf_kptr_xchg.md
+++ b/docs/linux/helper-function/bpf_kptr_xchg.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_kptr_xchg' - eBPF Docs"
+title: "Helper Function 'bpf_kptr_xchg'"
 description: "This page documents the 'bpf_kptr_xchg' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_kptr_xchg`

--- a/docs/linux/helper-function/bpf_ktime_get_boot_ns.md
+++ b/docs/linux/helper-function/bpf_ktime_get_boot_ns.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ktime_get_boot_ns' - eBPF Docs"
+title: "Helper Function 'bpf_ktime_get_boot_ns'"
 description: "This page documents the 'bpf_ktime_get_boot_ns' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ktime_get_boot_ns`

--- a/docs/linux/helper-function/bpf_ktime_get_coarse_ns.md
+++ b/docs/linux/helper-function/bpf_ktime_get_coarse_ns.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ktime_get_coarse_ns' - eBPF Docs"
+title: "Helper Function 'bpf_ktime_get_coarse_ns'"
 description: "This page documents the 'bpf_ktime_get_coarse_ns' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ktime_get_coarse_ns`

--- a/docs/linux/helper-function/bpf_ktime_get_ns.md
+++ b/docs/linux/helper-function/bpf_ktime_get_ns.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ktime_get_ns' - eBPF Docs"
+title: "Helper Function 'bpf_ktime_get_ns'"
 description: "This page documents the 'bpf_ktime_get_ns' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ktime_get_ns`

--- a/docs/linux/helper-function/bpf_ktime_get_tai_ns.md
+++ b/docs/linux/helper-function/bpf_ktime_get_tai_ns.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ktime_get_tai_ns' - eBPF Docs"
+title: "Helper Function 'bpf_ktime_get_tai_ns'"
 description: "This page documents the 'bpf_ktime_get_tai_ns' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ktime_get_tai_ns`

--- a/docs/linux/helper-function/bpf_l3_csum_replace.md
+++ b/docs/linux/helper-function/bpf_l3_csum_replace.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_l3_csum_replace' - eBPF Docs"
+title: "Helper Function 'bpf_l3_csum_replace'"
 description: "This page documents the 'bpf_l3_csum_replace' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_l3_csum_replace`

--- a/docs/linux/helper-function/bpf_l4_csum_replace.md
+++ b/docs/linux/helper-function/bpf_l4_csum_replace.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_l4_csum_replace' - eBPF Docs"
+title: "Helper Function 'bpf_l4_csum_replace'"
 description: "This page documents the 'bpf_l4_csum_replace' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_l4_csum_replace`

--- a/docs/linux/helper-function/bpf_load_hdr_opt.md
+++ b/docs/linux/helper-function/bpf_load_hdr_opt.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_load_hdr_opt' - eBPF Docs"
+title: "Helper Function 'bpf_load_hdr_opt'"
 description: "This page documents the 'bpf_load_hdr_opt' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_load_hdr_opt`

--- a/docs/linux/helper-function/bpf_loop.md
+++ b/docs/linux/helper-function/bpf_loop.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_loop' - eBPF Docs"
+title: "Helper Function 'bpf_loop'"
 description: "This page documents the 'bpf_loop' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_loop`

--- a/docs/linux/helper-function/bpf_lwt_push_encap.md
+++ b/docs/linux/helper-function/bpf_lwt_push_encap.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_lwt_push_encap' - eBPF Docs"
+title: "Helper Function 'bpf_lwt_push_encap'"
 description: "This page documents the 'bpf_lwt_push_encap' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_lwt_push_encap`

--- a/docs/linux/helper-function/bpf_lwt_seg6_action.md
+++ b/docs/linux/helper-function/bpf_lwt_seg6_action.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_lwt_seg6_action' - eBPF Docs"
+title: "Helper Function 'bpf_lwt_seg6_action'"
 description: "This page documents the 'bpf_lwt_seg6_action' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_lwt_seg6_action`

--- a/docs/linux/helper-function/bpf_lwt_seg6_adjust_srh.md
+++ b/docs/linux/helper-function/bpf_lwt_seg6_adjust_srh.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_lwt_seg6_adjust_srh' - eBPF Docs"
+title: "Helper Function 'bpf_lwt_seg6_adjust_srh'"
 description: "This page documents the 'bpf_lwt_seg6_adjust_srh' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_lwt_seg6_adjust_srh`

--- a/docs/linux/helper-function/bpf_lwt_seg6_store_bytes.md
+++ b/docs/linux/helper-function/bpf_lwt_seg6_store_bytes.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_lwt_seg6_store_bytes' - eBPF Docs"
+title: "Helper Function 'bpf_lwt_seg6_store_bytes'"
 description: "This page documents the 'bpf_lwt_seg6_store_bytes' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_lwt_seg6_store_bytes`

--- a/docs/linux/helper-function/bpf_map_delete_elem.md
+++ b/docs/linux/helper-function/bpf_map_delete_elem.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_map_delete_elem' - eBPF Docs"
+title: "Helper Function 'bpf_map_delete_elem'"
 description: "This page documents the 'bpf_map_delete_elem' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_map_delete_elem`

--- a/docs/linux/helper-function/bpf_map_lookup_elem.md
+++ b/docs/linux/helper-function/bpf_map_lookup_elem.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_map_lookup_elem' - eBPF Docs"
+title: "Helper Function 'bpf_map_lookup_elem'"
 description: "This page documents the 'bpf_map_lookup_elem' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_map_lookup_elem`

--- a/docs/linux/helper-function/bpf_map_lookup_percpu_elem.md
+++ b/docs/linux/helper-function/bpf_map_lookup_percpu_elem.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_map_lookup_percpu_elem' - eBPF Docs"
+title: "Helper Function 'bpf_map_lookup_percpu_elem'"
 description: "This page documents the 'bpf_map_lookup_percpu_elem' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_map_lookup_percpu_elem`

--- a/docs/linux/helper-function/bpf_map_peek_elem.md
+++ b/docs/linux/helper-function/bpf_map_peek_elem.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_map_peek_elem' - eBPF Docs"
+title: "Helper Function 'bpf_map_peek_elem'"
 description: "This page documents the 'bpf_map_peek_elem' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_map_peek_elem`

--- a/docs/linux/helper-function/bpf_map_pop_elem.md
+++ b/docs/linux/helper-function/bpf_map_pop_elem.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_map_pop_elem' - eBPF Docs"
+title: "Helper Function 'bpf_map_pop_elem'"
 description: "This page documents the 'bpf_map_pop_elem' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_map_pop_elem`

--- a/docs/linux/helper-function/bpf_map_push_elem.md
+++ b/docs/linux/helper-function/bpf_map_push_elem.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_map_push_elem' - eBPF Docs"
+title: "Helper Function 'bpf_map_push_elem'"
 description: "This page documents the 'bpf_map_push_elem' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_map_push_elem`

--- a/docs/linux/helper-function/bpf_map_update_elem.md
+++ b/docs/linux/helper-function/bpf_map_update_elem.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_map_update_elem' - eBPF Docs"
+title: "Helper Function 'bpf_map_update_elem'"
 description: "This page documents the 'bpf_map_update_elem' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_map_update_elem`

--- a/docs/linux/helper-function/bpf_msg_apply_bytes.md
+++ b/docs/linux/helper-function/bpf_msg_apply_bytes.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_msg_apply_bytes' - eBPF Docs"
+title: "Helper Function 'bpf_msg_apply_bytes'"
 description: "This page documents the 'bpf_msg_apply_bytes' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_msg_apply_bytes`

--- a/docs/linux/helper-function/bpf_msg_cork_bytes.md
+++ b/docs/linux/helper-function/bpf_msg_cork_bytes.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_msg_cork_bytes' - eBPF Docs"
+title: "Helper Function 'bpf_msg_cork_bytes'"
 description: "This page documents the 'bpf_msg_cork_bytes' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_msg_cork_bytes`

--- a/docs/linux/helper-function/bpf_msg_pop_data.md
+++ b/docs/linux/helper-function/bpf_msg_pop_data.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_msg_pop_data' - eBPF Docs"
+title: "Helper Function 'bpf_msg_pop_data'"
 description: "This page documents the 'bpf_msg_pop_data' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_msg_pop_data`

--- a/docs/linux/helper-function/bpf_msg_pull_data.md
+++ b/docs/linux/helper-function/bpf_msg_pull_data.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_msg_pull_data' - eBPF Docs"
+title: "Helper Function 'bpf_msg_pull_data'"
 description: "This page documents the 'bpf_msg_pull_data' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_msg_pull_data`

--- a/docs/linux/helper-function/bpf_msg_push_data.md
+++ b/docs/linux/helper-function/bpf_msg_push_data.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_msg_push_data' - eBPF Docs"
+title: "Helper Function 'bpf_msg_push_data'"
 description: "This page documents the 'bpf_msg_push_data' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_msg_push_data`

--- a/docs/linux/helper-function/bpf_msg_redirect_hash.md
+++ b/docs/linux/helper-function/bpf_msg_redirect_hash.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_msg_redirect_hash' - eBPF Docs"
+title: "Helper Function 'bpf_msg_redirect_hash'"
 description: "This page documents the 'bpf_msg_redirect_hash' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_msg_redirect_hash`

--- a/docs/linux/helper-function/bpf_msg_redirect_map.md
+++ b/docs/linux/helper-function/bpf_msg_redirect_map.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_msg_redirect_map' - eBPF Docs"
+title: "Helper Function 'bpf_msg_redirect_map'"
 description: "This page documents the 'bpf_msg_redirect_map' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_msg_redirect_map`

--- a/docs/linux/helper-function/bpf_override_return.md
+++ b/docs/linux/helper-function/bpf_override_return.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_override_return' - eBPF Docs"
+title: "Helper Function 'bpf_override_return'"
 description: "This page documents the 'bpf_override_return' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_override_return`

--- a/docs/linux/helper-function/bpf_per_cpu_ptr.md
+++ b/docs/linux/helper-function/bpf_per_cpu_ptr.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_per_cpu_ptr' - eBPF Docs"
+title: "Helper Function 'bpf_per_cpu_ptr'"
 description: "This page documents the 'bpf_per_cpu_ptr' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_per_cpu_ptr`

--- a/docs/linux/helper-function/bpf_perf_event_output.md
+++ b/docs/linux/helper-function/bpf_perf_event_output.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_perf_event_output' - eBPF Docs"
+title: "Helper Function 'bpf_perf_event_output'"
 description: "This page documents the 'bpf_perf_event_output' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_perf_event_output`

--- a/docs/linux/helper-function/bpf_perf_event_read.md
+++ b/docs/linux/helper-function/bpf_perf_event_read.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_perf_event_read' - eBPF Docs"
+title: "Helper Function 'bpf_perf_event_read'"
 description: "This page documents the 'bpf_perf_event_read' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_perf_event_read`

--- a/docs/linux/helper-function/bpf_perf_event_read_value.md
+++ b/docs/linux/helper-function/bpf_perf_event_read_value.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_perf_event_read_value' - eBPF Docs"
+title: "Helper Function 'bpf_perf_event_read_value'"
 description: "This page documents the 'bpf_perf_event_read_value' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_perf_event_read_value`

--- a/docs/linux/helper-function/bpf_perf_prog_read_value.md
+++ b/docs/linux/helper-function/bpf_perf_prog_read_value.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_perf_prog_read_value' - eBPF Docs"
+title: "Helper Function 'bpf_perf_prog_read_value'"
 description: "This page documents the 'bpf_perf_prog_read_value' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_perf_prog_read_value`

--- a/docs/linux/helper-function/bpf_probe_read.md
+++ b/docs/linux/helper-function/bpf_probe_read.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_probe_read' - eBPF Docs"
+title: "Helper Function 'bpf_probe_read'"
 description: "This page documents the 'bpf_probe_read' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_probe_read`

--- a/docs/linux/helper-function/bpf_probe_read_kernel.md
+++ b/docs/linux/helper-function/bpf_probe_read_kernel.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_probe_read_kernel' - eBPF Docs"
+title: "Helper Function 'bpf_probe_read_kernel'"
 description: "This page documents the 'bpf_probe_read_kernel' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_probe_read_kernel`

--- a/docs/linux/helper-function/bpf_probe_read_kernel_str.md
+++ b/docs/linux/helper-function/bpf_probe_read_kernel_str.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_probe_read_kernel_str' - eBPF Docs"
+title: "Helper Function 'bpf_probe_read_kernel_str'"
 description: "This page documents the 'bpf_probe_read_kernel_str' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_probe_read_kernel_str`

--- a/docs/linux/helper-function/bpf_probe_read_str.md
+++ b/docs/linux/helper-function/bpf_probe_read_str.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_probe_read_str' - eBPF Docs"
+title: "Helper Function 'bpf_probe_read_str'"
 description: "This page documents the 'bpf_probe_read_str' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_probe_read_str`

--- a/docs/linux/helper-function/bpf_probe_read_user.md
+++ b/docs/linux/helper-function/bpf_probe_read_user.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_probe_read_user' - eBPF Docs"
+title: "Helper Function 'bpf_probe_read_user'"
 description: "This page documents the 'bpf_probe_read_user' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_probe_read_user`

--- a/docs/linux/helper-function/bpf_probe_read_user_str.md
+++ b/docs/linux/helper-function/bpf_probe_read_user_str.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_probe_read_user_str' - eBPF Docs"
+title: "Helper Function 'bpf_probe_read_user_str'"
 description: "This page documents the 'bpf_probe_read_user_str' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_probe_read_user_str`

--- a/docs/linux/helper-function/bpf_probe_write_user.md
+++ b/docs/linux/helper-function/bpf_probe_write_user.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_probe_write_user' - eBPF Docs"
+title: "Helper Function 'bpf_probe_write_user'"
 description: "This page documents the 'bpf_probe_write_user' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_probe_write_user`

--- a/docs/linux/helper-function/bpf_rc_keydown.md
+++ b/docs/linux/helper-function/bpf_rc_keydown.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_rc_keydown' - eBPF Docs"
+title: "Helper Function 'bpf_rc_keydown'"
 description: "This page documents the 'bpf_rc_keydown' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_rc_keydown`

--- a/docs/linux/helper-function/bpf_rc_pointer_rel.md
+++ b/docs/linux/helper-function/bpf_rc_pointer_rel.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_rc_pointer_rel' - eBPF Docs"
+title: "Helper Function 'bpf_rc_pointer_rel'"
 description: "This page documents the 'bpf_rc_pointer_rel' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_rc_pointer_rel`

--- a/docs/linux/helper-function/bpf_rc_repeat.md
+++ b/docs/linux/helper-function/bpf_rc_repeat.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_rc_repeat' - eBPF Docs"
+title: "Helper Function 'bpf_rc_repeat'"
 description: "This page documents the 'bpf_rc_repeat' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_rc_repeat`

--- a/docs/linux/helper-function/bpf_read_branch_records.md
+++ b/docs/linux/helper-function/bpf_read_branch_records.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_read_branch_records' - eBPF Docs"
+title: "Helper Function 'bpf_read_branch_records'"
 description: "This page documents the 'bpf_read_branch_records' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_read_branch_records`

--- a/docs/linux/helper-function/bpf_redirect.md
+++ b/docs/linux/helper-function/bpf_redirect.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_redirect' - eBPF Docs"
+title: "Helper Function 'bpf_redirect'"
 description: "This page documents the 'bpf_redirect' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_redirect`

--- a/docs/linux/helper-function/bpf_redirect_map.md
+++ b/docs/linux/helper-function/bpf_redirect_map.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_redirect_map' - eBPF Docs"
+title: "Helper Function 'bpf_redirect_map'"
 description: "This page documents the 'bpf_redirect_map' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_redirect_map`

--- a/docs/linux/helper-function/bpf_redirect_neigh.md
+++ b/docs/linux/helper-function/bpf_redirect_neigh.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_redirect_neigh' - eBPF Docs"
+title: "Helper Function 'bpf_redirect_neigh'"
 description: "This page documents the 'bpf_redirect_neigh' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_redirect_neigh`

--- a/docs/linux/helper-function/bpf_redirect_peer.md
+++ b/docs/linux/helper-function/bpf_redirect_peer.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_redirect_peer' - eBPF Docs"
+title: "Helper Function 'bpf_redirect_peer'"
 description: "This page documents the 'bpf_redirect_peer' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_redirect_peer`

--- a/docs/linux/helper-function/bpf_reserve_hdr_opt.md
+++ b/docs/linux/helper-function/bpf_reserve_hdr_opt.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_reserve_hdr_opt' - eBPF Docs"
+title: "Helper Function 'bpf_reserve_hdr_opt'"
 description: "This page documents the 'bpf_reserve_hdr_opt' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_reserve_hdr_opt`

--- a/docs/linux/helper-function/bpf_ringbuf_discard.md
+++ b/docs/linux/helper-function/bpf_ringbuf_discard.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ringbuf_discard' - eBPF Docs"
+title: "Helper Function 'bpf_ringbuf_discard'"
 description: "This page documents the 'bpf_ringbuf_discard' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ringbuf_discard_dynptr`

--- a/docs/linux/helper-function/bpf_ringbuf_discard_dynptr.md
+++ b/docs/linux/helper-function/bpf_ringbuf_discard_dynptr.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ringbuf_discard_dynptr' - eBPF Docs"
+title: "Helper Function 'bpf_ringbuf_discard_dynptr'"
 description: "This page documents the 'bpf_ringbuf_discard_dynptr' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ringbuf_discard_dynptr`

--- a/docs/linux/helper-function/bpf_ringbuf_output.md
+++ b/docs/linux/helper-function/bpf_ringbuf_output.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ringbuf_output' - eBPF Docs"
+title: "Helper Function 'bpf_ringbuf_output'"
 description: "This page documents the 'bpf_ringbuf_output' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ringbuf_discard_dynptr`

--- a/docs/linux/helper-function/bpf_ringbuf_query.md
+++ b/docs/linux/helper-function/bpf_ringbuf_query.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ringbuf_query' - eBPF Docs"
+title: "Helper Function 'bpf_ringbuf_query'"
 description: "This page documents the 'bpf_ringbuf_query' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ringbuf_discard_dynptr`

--- a/docs/linux/helper-function/bpf_ringbuf_reserve.md
+++ b/docs/linux/helper-function/bpf_ringbuf_reserve.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ringbuf_reserve' - eBPF Docs"
+title: "Helper Function 'bpf_ringbuf_reserve'"
 description: "This page documents the 'bpf_ringbuf_reserve' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ringbuf_discard_dynptr`

--- a/docs/linux/helper-function/bpf_ringbuf_reserve_dynptr.md
+++ b/docs/linux/helper-function/bpf_ringbuf_reserve_dynptr.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ringbuf_reserve_dynptr' - eBPF Docs"
+title: "Helper Function 'bpf_ringbuf_reserve_dynptr'"
 description: "This page documents the 'bpf_ringbuf_reserve_dynptr' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ringbuf_discard_dynptr`

--- a/docs/linux/helper-function/bpf_ringbuf_submit.md
+++ b/docs/linux/helper-function/bpf_ringbuf_submit.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ringbuf_submit' - eBPF Docs"
+title: "Helper Function 'bpf_ringbuf_submit'"
 description: "This page documents the 'bpf_ringbuf_submit' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ringbuf_discard_dynptr`

--- a/docs/linux/helper-function/bpf_ringbuf_submit_dynptr.md
+++ b/docs/linux/helper-function/bpf_ringbuf_submit_dynptr.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_ringbuf_submit_dynptr' - eBPF Docs"
+title: "Helper Function 'bpf_ringbuf_submit_dynptr'"
 description: "This page documents the 'bpf_ringbuf_submit_dynptr' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_ringbuf_discard_dynptr`

--- a/docs/linux/helper-function/bpf_send_signal.md
+++ b/docs/linux/helper-function/bpf_send_signal.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_send_signal' - eBPF Docs"
+title: "Helper Function 'bpf_send_signal'"
 description: "This page documents the 'bpf_send_signal' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_send_signal`

--- a/docs/linux/helper-function/bpf_send_signal_thread.md
+++ b/docs/linux/helper-function/bpf_send_signal_thread.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_send_signal_thread' - eBPF Docs"
+title: "Helper Function 'bpf_send_signal_thread'"
 description: "This page documents the 'bpf_send_signal_thread' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_send_signal_thread`

--- a/docs/linux/helper-function/bpf_seq_printf.md
+++ b/docs/linux/helper-function/bpf_seq_printf.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_seq_printf' - eBPF Docs"
+title: "Helper Function 'bpf_seq_printf'"
 description: "This page documents the 'bpf_seq_printf' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_seq_printf`

--- a/docs/linux/helper-function/bpf_seq_printf_btf.md
+++ b/docs/linux/helper-function/bpf_seq_printf_btf.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_seq_printf_btf' - eBPF Docs"
+title: "Helper Function 'bpf_seq_printf_btf'"
 description: "This page documents the 'bpf_seq_printf_btf' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_seq_printf_btf`

--- a/docs/linux/helper-function/bpf_seq_write.md
+++ b/docs/linux/helper-function/bpf_seq_write.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_seq_write' - eBPF Docs"
+title: "Helper Function 'bpf_seq_write'"
 description: "This page documents the 'bpf_seq_write' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_seq_write`

--- a/docs/linux/helper-function/bpf_set_hash.md
+++ b/docs/linux/helper-function/bpf_set_hash.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_set_hash' - eBPF Docs"
+title: "Helper Function 'bpf_set_hash'"
 description: "This page documents the 'bpf_set_hash' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_set_hash`

--- a/docs/linux/helper-function/bpf_set_hash_invalid.md
+++ b/docs/linux/helper-function/bpf_set_hash_invalid.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_set_hash_invalid' - eBPF Docs"
+title: "Helper Function 'bpf_set_hash_invalid'"
 description: "This page documents the 'bpf_set_hash_invalid' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_set_hash_invalid`

--- a/docs/linux/helper-function/bpf_set_retval.md
+++ b/docs/linux/helper-function/bpf_set_retval.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_set_retval' - eBPF Docs"
+title: "Helper Function 'bpf_set_retval'"
 description: "This page documents the 'bpf_set_retval' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_set_retval`

--- a/docs/linux/helper-function/bpf_setsockopt.md
+++ b/docs/linux/helper-function/bpf_setsockopt.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_setsockopt' - eBPF Docs"
+title: "Helper Function 'bpf_setsockopt'"
 description: "This page documents the 'bpf_setsockopt' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_setsockopt`

--- a/docs/linux/helper-function/bpf_sk_ancestor_cgroup_id.md
+++ b/docs/linux/helper-function/bpf_sk_ancestor_cgroup_id.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sk_ancestor_cgroup_id' - eBPF Docs"
+title: "Helper Function 'bpf_sk_ancestor_cgroup_id'"
 description: "This page documents the 'bpf_sk_ancestor_cgroup_id' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sk_ancestor_cgroup_id`

--- a/docs/linux/helper-function/bpf_sk_assign.md
+++ b/docs/linux/helper-function/bpf_sk_assign.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sk_assign' - eBPF Docs"
+title: "Helper Function 'bpf_sk_assign'"
 description: "This page documents the 'bpf_sk_assign' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sk_assign`

--- a/docs/linux/helper-function/bpf_sk_cgroup_id.md
+++ b/docs/linux/helper-function/bpf_sk_cgroup_id.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sk_cgroup_id' - eBPF Docs"
+title: "Helper Function 'bpf_sk_cgroup_id'"
 description: "This page documents the 'bpf_sk_cgroup_id' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sk_cgroup_id`

--- a/docs/linux/helper-function/bpf_sk_fullsock.md
+++ b/docs/linux/helper-function/bpf_sk_fullsock.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sk_fullsock' - eBPF Docs"
+title: "Helper Function 'bpf_sk_fullsock'"
 description: "This page documents the 'bpf_sk_fullsock' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sk_fullsock`

--- a/docs/linux/helper-function/bpf_sk_lookup_tcp.md
+++ b/docs/linux/helper-function/bpf_sk_lookup_tcp.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sk_lookup_tcp' - eBPF Docs"
+title: "Helper Function 'bpf_sk_lookup_tcp'"
 description: "This page documents the 'bpf_sk_lookup_tcp' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sk_lookup_tcp`

--- a/docs/linux/helper-function/bpf_sk_lookup_udp.md
+++ b/docs/linux/helper-function/bpf_sk_lookup_udp.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sk_lookup_udp' - eBPF Docs"
+title: "Helper Function 'bpf_sk_lookup_udp'"
 description: "This page documents the 'bpf_sk_lookup_udp' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sk_lookup_udp`

--- a/docs/linux/helper-function/bpf_sk_redirect_hash.md
+++ b/docs/linux/helper-function/bpf_sk_redirect_hash.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sk_redirect_hash' - eBPF Docs"
+title: "Helper Function 'bpf_sk_redirect_hash'"
 description: "This page documents the 'bpf_sk_redirect_hash' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sk_redirect_hash`

--- a/docs/linux/helper-function/bpf_sk_redirect_map.md
+++ b/docs/linux/helper-function/bpf_sk_redirect_map.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sk_redirect_map' - eBPF Docs"
+title: "Helper Function 'bpf_sk_redirect_map'"
 description: "This page documents the 'bpf_sk_redirect_map' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sk_redirect_map`

--- a/docs/linux/helper-function/bpf_sk_release.md
+++ b/docs/linux/helper-function/bpf_sk_release.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sk_release' - eBPF Docs"
+title: "Helper Function 'bpf_sk_release'"
 description: "This page documents the 'bpf_sk_release' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sk_release`

--- a/docs/linux/helper-function/bpf_sk_select_reuseport.md
+++ b/docs/linux/helper-function/bpf_sk_select_reuseport.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sk_select_reuseport' - eBPF Docs"
+title: "Helper Function 'bpf_sk_select_reuseport'"
 description: "This page documents the 'bpf_sk_select_reuseport' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sk_select_reuseport`

--- a/docs/linux/helper-function/bpf_sk_storage_delete.md
+++ b/docs/linux/helper-function/bpf_sk_storage_delete.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sk_storage_delete' - eBPF Docs"
+title: "Helper Function 'bpf_sk_storage_delete'"
 description: "This page documents the 'bpf_sk_storage_delete' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sk_storage_delete`

--- a/docs/linux/helper-function/bpf_sk_storage_get.md
+++ b/docs/linux/helper-function/bpf_sk_storage_get.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sk_storage_get' - eBPF Docs"
+title: "Helper Function 'bpf_sk_storage_get'"
 description: "This page documents the 'bpf_sk_storage_get' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sk_storage_get`

--- a/docs/linux/helper-function/bpf_skb_adjust_room.md
+++ b/docs/linux/helper-function/bpf_skb_adjust_room.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_adjust_room' - eBPF Docs"
+title: "Helper Function 'bpf_skb_adjust_room'"
 description: "This page documents the 'bpf_skb_adjust_room' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_adjust_room`

--- a/docs/linux/helper-function/bpf_skb_ancestor_cgroup_id.md
+++ b/docs/linux/helper-function/bpf_skb_ancestor_cgroup_id.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_ancestor_cgroup_id' - eBPF Docs"
+title: "Helper Function 'bpf_skb_ancestor_cgroup_id'"
 description: "This page documents the 'bpf_skb_ancestor_cgroup_id' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_ancestor_cgroup_id`

--- a/docs/linux/helper-function/bpf_skb_cgroup_classid.md
+++ b/docs/linux/helper-function/bpf_skb_cgroup_classid.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_cgroup_classid' - eBPF Docs"
+title: "Helper Function 'bpf_skb_cgroup_classid'"
 description: "This page documents the 'bpf_skb_cgroup_classid' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_cgroup_classid`

--- a/docs/linux/helper-function/bpf_skb_cgroup_id.md
+++ b/docs/linux/helper-function/bpf_skb_cgroup_id.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_cgroup_id' - eBPF Docs"
+title: "Helper Function 'bpf_skb_cgroup_id'"
 description: "This page documents the 'bpf_skb_cgroup_id' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_cgroup_id`

--- a/docs/linux/helper-function/bpf_skb_change_head.md
+++ b/docs/linux/helper-function/bpf_skb_change_head.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_change_head' - eBPF Docs"
+title: "Helper Function 'bpf_skb_change_head'"
 description: "This page documents the 'bpf_skb_change_head' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_change_head`

--- a/docs/linux/helper-function/bpf_skb_change_proto.md
+++ b/docs/linux/helper-function/bpf_skb_change_proto.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_change_proto' - eBPF Docs"
+title: "Helper Function 'bpf_skb_change_proto'"
 description: "This page documents the 'bpf_skb_change_proto' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_change_proto`

--- a/docs/linux/helper-function/bpf_skb_change_tail.md
+++ b/docs/linux/helper-function/bpf_skb_change_tail.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_change_tail' - eBPF Docs"
+title: "Helper Function 'bpf_skb_change_tail'"
 description: "This page documents the 'bpf_skb_change_tail' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_change_tail`

--- a/docs/linux/helper-function/bpf_skb_change_type.md
+++ b/docs/linux/helper-function/bpf_skb_change_type.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_change_type' - eBPF Docs"
+title: "Helper Function 'bpf_skb_change_type'"
 description: "This page documents the 'bpf_skb_change_type' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_change_type`

--- a/docs/linux/helper-function/bpf_skb_ecn_set_ce.md
+++ b/docs/linux/helper-function/bpf_skb_ecn_set_ce.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_ecn_set_ce' - eBPF Docs"
+title: "Helper Function 'bpf_skb_ecn_set_ce'"
 description: "This page documents the 'bpf_skb_ecn_set_ce' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_ecn_set_ce`

--- a/docs/linux/helper-function/bpf_skb_get_tunnel_key.md
+++ b/docs/linux/helper-function/bpf_skb_get_tunnel_key.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_get_tunnel_key' - eBPF Docs"
+title: "Helper Function 'bpf_skb_get_tunnel_key'"
 description: "This page documents the 'bpf_skb_get_tunnel_key' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_get_tunnel_key`

--- a/docs/linux/helper-function/bpf_skb_get_tunnel_opt.md
+++ b/docs/linux/helper-function/bpf_skb_get_tunnel_opt.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_get_tunnel_opt' - eBPF Docs"
+title: "Helper Function 'bpf_skb_get_tunnel_opt'"
 description: "This page documents the 'bpf_skb_get_tunnel_opt' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_get_tunnel_opt`

--- a/docs/linux/helper-function/bpf_skb_get_xfrm_state.md
+++ b/docs/linux/helper-function/bpf_skb_get_xfrm_state.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_get_xfrm_state' - eBPF Docs"
+title: "Helper Function 'bpf_skb_get_xfrm_state'"
 description: "This page documents the 'bpf_skb_get_xfrm_state' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_get_xfrm_state`

--- a/docs/linux/helper-function/bpf_skb_load_bytes.md
+++ b/docs/linux/helper-function/bpf_skb_load_bytes.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_load_bytes' - eBPF Docs"
+title: "Helper Function 'bpf_skb_load_bytes'"
 description: "This page documents the 'bpf_skb_load_bytes' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_load_bytes`

--- a/docs/linux/helper-function/bpf_skb_load_bytes_relative.md
+++ b/docs/linux/helper-function/bpf_skb_load_bytes_relative.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_load_bytes_relative' - eBPF Docs"
+title: "Helper Function 'bpf_skb_load_bytes_relative'"
 description: "This page documents the 'bpf_skb_load_bytes_relative' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_load_bytes_relative`

--- a/docs/linux/helper-function/bpf_skb_output.md
+++ b/docs/linux/helper-function/bpf_skb_output.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_output' - eBPF Docs"
+title: "Helper Function 'bpf_skb_output'"
 description: "This page documents the 'bpf_skb_output' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_output`

--- a/docs/linux/helper-function/bpf_skb_pull_data.md
+++ b/docs/linux/helper-function/bpf_skb_pull_data.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_pull_data' - eBPF Docs"
+title: "Helper Function 'bpf_skb_pull_data'"
 description: "This page documents the 'bpf_skb_pull_data' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_pull_data`

--- a/docs/linux/helper-function/bpf_skb_set_tstamp.md
+++ b/docs/linux/helper-function/bpf_skb_set_tstamp.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_set_tstamp' - eBPF Docs"
+title: "Helper Function 'bpf_skb_set_tstamp'"
 description: "This page documents the 'bpf_skb_set_tstamp' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_set_tstamp`

--- a/docs/linux/helper-function/bpf_skb_set_tunnel_key.md
+++ b/docs/linux/helper-function/bpf_skb_set_tunnel_key.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_set_tunnel_key' - eBPF Docs"
+title: "Helper Function 'bpf_skb_set_tunnel_key'"
 description: "This page documents the 'bpf_skb_set_tunnel_key' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_set_tunnel_key`

--- a/docs/linux/helper-function/bpf_skb_set_tunnel_opt.md
+++ b/docs/linux/helper-function/bpf_skb_set_tunnel_opt.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_set_tunnel_opt' - eBPF Docs"
+title: "Helper Function 'bpf_skb_set_tunnel_opt'"
 description: "This page documents the 'bpf_skb_set_tunnel_opt' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_set_tunnel_opt`

--- a/docs/linux/helper-function/bpf_skb_store_bytes.md
+++ b/docs/linux/helper-function/bpf_skb_store_bytes.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_store_bytes' - eBPF Docs"
+title: "Helper Function 'bpf_skb_store_bytes'"
 description: "This page documents the 'bpf_skb_store_bytes' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_store_bytes`

--- a/docs/linux/helper-function/bpf_skb_under_cgroup.md
+++ b/docs/linux/helper-function/bpf_skb_under_cgroup.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_under_cgroup' - eBPF Docs"
+title: "Helper Function 'bpf_skb_under_cgroup'"
 description: "This page documents the 'bpf_skb_under_cgroup' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_under_cgroup`

--- a/docs/linux/helper-function/bpf_skb_vlan_pop.md
+++ b/docs/linux/helper-function/bpf_skb_vlan_pop.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_vlan_pop' - eBPF Docs"
+title: "Helper Function 'bpf_skb_vlan_pop'"
 description: "This page documents the 'bpf_skb_vlan_pop' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_vlan_pop`

--- a/docs/linux/helper-function/bpf_skb_vlan_push.md
+++ b/docs/linux/helper-function/bpf_skb_vlan_push.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skb_vlan_push' - eBPF Docs"
+title: "Helper Function 'bpf_skb_vlan_push'"
 description: "This page documents the 'bpf_skb_vlan_push' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skb_vlan_push`

--- a/docs/linux/helper-function/bpf_skc_lookup_tcp.md
+++ b/docs/linux/helper-function/bpf_skc_lookup_tcp.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skc_lookup_tcp' - eBPF Docs"
+title: "Helper Function 'bpf_skc_lookup_tcp'"
 description: "This page documents the 'bpf_skc_lookup_tcp' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skc_lookup_tcp`

--- a/docs/linux/helper-function/bpf_skc_to_mptcp_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_mptcp_sock.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skc_to_mptcp_sock' - eBPF Docs"
+title: "Helper Function 'bpf_skc_to_mptcp_sock'"
 description: "This page documents the 'bpf_skc_to_mptcp_sock' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skc_to_mptcp_sock`

--- a/docs/linux/helper-function/bpf_skc_to_tcp6_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_tcp6_sock.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skc_to_tcp6_sock' - eBPF Docs"
+title: "Helper Function 'bpf_skc_to_tcp6_sock'"
 description: "This page documents the 'bpf_skc_to_tcp6_sock' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skc_to_tcp6_sock`

--- a/docs/linux/helper-function/bpf_skc_to_tcp_request_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_tcp_request_sock.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skc_to_tcp_request_sock' - eBPF Docs"
+title: "Helper Function 'bpf_skc_to_tcp_request_sock'"
 description: "This page documents the 'bpf_skc_to_tcp_request_sock' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skc_to_tcp_request_sock`

--- a/docs/linux/helper-function/bpf_skc_to_tcp_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_tcp_sock.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skc_to_tcp_sock' - eBPF Docs"
+title: "Helper Function 'bpf_skc_to_tcp_sock'"
 description: "This page documents the 'bpf_skc_to_tcp_sock' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skc_to_tcp_sock`

--- a/docs/linux/helper-function/bpf_skc_to_tcp_timewait_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_tcp_timewait_sock.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skc_to_tcp_timewait_sock' - eBPF Docs"
+title: "Helper Function 'bpf_skc_to_tcp_timewait_sock'"
 description: "This page documents the 'bpf_skc_to_tcp_timewait_sock' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skc_to_tcp_timewait_sock`

--- a/docs/linux/helper-function/bpf_skc_to_udp6_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_udp6_sock.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skc_to_udp6_sock' - eBPF Docs"
+title: "Helper Function 'bpf_skc_to_udp6_sock'"
 description: "This page documents the 'bpf_skc_to_udp6_sock' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skc_to_udp6_sock`

--- a/docs/linux/helper-function/bpf_skc_to_unix_sock.md
+++ b/docs/linux/helper-function/bpf_skc_to_unix_sock.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_skc_to_unix_sock' - eBPF Docs"
+title: "Helper Function 'bpf_skc_to_unix_sock'"
 description: "This page documents the 'bpf_skc_to_unix_sock' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_skc_to_unix_sock`

--- a/docs/linux/helper-function/bpf_snprintf.md
+++ b/docs/linux/helper-function/bpf_snprintf.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_snprintf' - eBPF Docs"
+title: "Helper Function 'bpf_snprintf'"
 description: "This page documents the 'bpf_snprintf' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_snprintf`

--- a/docs/linux/helper-function/bpf_snprintf_btf.md
+++ b/docs/linux/helper-function/bpf_snprintf_btf.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_snprintf_btf' - eBPF Docs"
+title: "Helper Function 'bpf_snprintf_btf'"
 description: "This page documents the 'bpf_snprintf_btf' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_snprintf_btf`

--- a/docs/linux/helper-function/bpf_sock_from_file.md
+++ b/docs/linux/helper-function/bpf_sock_from_file.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sock_from_file' - eBPF Docs"
+title: "Helper Function 'bpf_sock_from_file'"
 description: "This page documents the 'bpf_sock_from_file' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sock_from_file`

--- a/docs/linux/helper-function/bpf_sock_hash_update.md
+++ b/docs/linux/helper-function/bpf_sock_hash_update.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sock_hash_update' - eBPF Docs"
+title: "Helper Function 'bpf_sock_hash_update'"
 description: "This page documents the 'bpf_sock_hash_update' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sock_hash_update`

--- a/docs/linux/helper-function/bpf_sock_map_update.md
+++ b/docs/linux/helper-function/bpf_sock_map_update.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sock_map_update' - eBPF Docs"
+title: "Helper Function 'bpf_sock_map_update'"
 description: "This page documents the 'bpf_sock_map_update' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sock_map_update`

--- a/docs/linux/helper-function/bpf_sock_ops_cb_flags_set.md
+++ b/docs/linux/helper-function/bpf_sock_ops_cb_flags_set.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sock_ops_cb_flags_set' - eBPF Docs"
+title: "Helper Function 'bpf_sock_ops_cb_flags_set'"
 description: "This page documents the 'bpf_sock_ops_cb_flags_set' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sock_ops_cb_flags_set`

--- a/docs/linux/helper-function/bpf_spin_lock.md
+++ b/docs/linux/helper-function/bpf_spin_lock.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_spin_lock' - eBPF Docs"
+title: "Helper Function 'bpf_spin_lock'"
 description: "This page documents the 'bpf_spin_lock' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_spin_lock`

--- a/docs/linux/helper-function/bpf_spin_unlock.md
+++ b/docs/linux/helper-function/bpf_spin_unlock.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_spin_unlock' - eBPF Docs"
+title: "Helper Function 'bpf_spin_unlock'"
 description: "This page documents the 'bpf_spin_unlock' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_spin_unlock`

--- a/docs/linux/helper-function/bpf_store_hdr_opt.md
+++ b/docs/linux/helper-function/bpf_store_hdr_opt.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_store_hdr_opt' - eBPF Docs"
+title: "Helper Function 'bpf_store_hdr_opt'"
 description: "This page documents the 'bpf_store_hdr_opt' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_store_hdr_opt`

--- a/docs/linux/helper-function/bpf_strncmp.md
+++ b/docs/linux/helper-function/bpf_strncmp.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_strncmp' - eBPF Docs"
+title: "Helper Function 'bpf_strncmp'"
 description: "This page documents the 'bpf_strncmp' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_strncmp`

--- a/docs/linux/helper-function/bpf_strtol.md
+++ b/docs/linux/helper-function/bpf_strtol.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_strtol' - eBPF Docs"
+title: "Helper Function 'bpf_strtol'"
 description: "This page documents the 'bpf_strtol' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_strtol`

--- a/docs/linux/helper-function/bpf_strtoul.md
+++ b/docs/linux/helper-function/bpf_strtoul.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_strtoul' - eBPF Docs"
+title: "Helper Function 'bpf_strtoul'"
 description: "This page documents the 'bpf_strtoul' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_strtoul`

--- a/docs/linux/helper-function/bpf_sys_bpf.md
+++ b/docs/linux/helper-function/bpf_sys_bpf.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sys_bpf' - eBPF Docs"
+title: "Helper Function 'bpf_sys_bpf'"
 description: "This page documents the 'bpf_sys_bpf' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sys_bpf`

--- a/docs/linux/helper-function/bpf_sys_close.md
+++ b/docs/linux/helper-function/bpf_sys_close.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sys_close' - eBPF Docs"
+title: "Helper Function 'bpf_sys_close'"
 description: "This page documents the 'bpf_sys_close' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sys_close`

--- a/docs/linux/helper-function/bpf_sysctl_get_current_value.md
+++ b/docs/linux/helper-function/bpf_sysctl_get_current_value.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sysctl_get_current_value' - eBPF Docs"
+title: "Helper Function 'bpf_sysctl_get_current_value'"
 description: "This page documents the 'bpf_sysctl_get_current_value' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sysctl_get_current_value`

--- a/docs/linux/helper-function/bpf_sysctl_get_name.md
+++ b/docs/linux/helper-function/bpf_sysctl_get_name.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sysctl_get_name' - eBPF Docs"
+title: "Helper Function 'bpf_sysctl_get_name'"
 description: "This page documents the 'bpf_sysctl_get_name' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sysctl_get_name`

--- a/docs/linux/helper-function/bpf_sysctl_get_new_value.md
+++ b/docs/linux/helper-function/bpf_sysctl_get_new_value.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sysctl_get_new_value' - eBPF Docs"
+title: "Helper Function 'bpf_sysctl_get_new_value'"
 description: "This page documents the 'bpf_sysctl_get_new_value' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sysctl_get_new_value`

--- a/docs/linux/helper-function/bpf_sysctl_set_new_value.md
+++ b/docs/linux/helper-function/bpf_sysctl_set_new_value.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_sysctl_set_new_value' - eBPF Docs"
+title: "Helper Function 'bpf_sysctl_set_new_value'"
 description: "This page documents the 'bpf_sysctl_set_new_value' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_sysctl_set_new_value`

--- a/docs/linux/helper-function/bpf_tail_call.md
+++ b/docs/linux/helper-function/bpf_tail_call.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_tail_call' - eBPF Docs"
+title: "Helper Function 'bpf_tail_call'"
 description: "This page documents the 'bpf_tail_call' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_tail_call`

--- a/docs/linux/helper-function/bpf_task_pt_regs.md
+++ b/docs/linux/helper-function/bpf_task_pt_regs.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_task_pt_regs' - eBPF Docs"
+title: "Helper Function 'bpf_task_pt_regs'"
 description: "This page documents the 'bpf_task_pt_regs' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_task_pt_regs`

--- a/docs/linux/helper-function/bpf_task_storage_delete.md
+++ b/docs/linux/helper-function/bpf_task_storage_delete.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_task_storage_delete' - eBPF Docs"
+title: "Helper Function 'bpf_task_storage_delete'"
 description: "This page documents the 'bpf_task_storage_delete' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_task_storage_delete`

--- a/docs/linux/helper-function/bpf_task_storage_get.md
+++ b/docs/linux/helper-function/bpf_task_storage_get.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_task_storage_get' - eBPF Docs"
+title: "Helper Function 'bpf_task_storage_get'"
 description: "This page documents the 'bpf_task_storage_get' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_task_storage_get`

--- a/docs/linux/helper-function/bpf_tcp_check_syncookie.md
+++ b/docs/linux/helper-function/bpf_tcp_check_syncookie.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_tcp_check_syncookie' - eBPF Docs"
+title: "Helper Function 'bpf_tcp_check_syncookie'"
 description: "This page documents the 'bpf_tcp_check_syncookie' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_tcp_check_syncookie`

--- a/docs/linux/helper-function/bpf_tcp_gen_syncookie.md
+++ b/docs/linux/helper-function/bpf_tcp_gen_syncookie.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_tcp_gen_syncookie' - eBPF Docs"
+title: "Helper Function 'bpf_tcp_gen_syncookie'"
 description: "This page documents the 'bpf_tcp_gen_syncookie' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_tcp_gen_syncookie`

--- a/docs/linux/helper-function/bpf_tcp_raw_check_syncookie_ipv4.md
+++ b/docs/linux/helper-function/bpf_tcp_raw_check_syncookie_ipv4.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_tcp_raw_check_syncookie_ipv4' - eBPF Docs"
+title: "Helper Function 'bpf_tcp_raw_check_syncookie_ipv4'"
 description: "This page documents the 'bpf_tcp_raw_check_syncookie_ipv4' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_tcp_raw_check_syncookie_ipv4`

--- a/docs/linux/helper-function/bpf_tcp_raw_check_syncookie_ipv6.md
+++ b/docs/linux/helper-function/bpf_tcp_raw_check_syncookie_ipv6.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_tcp_raw_check_syncookie_ipv6' - eBPF Docs"
+title: "Helper Function 'bpf_tcp_raw_check_syncookie_ipv6'"
 description: "This page documents the 'bpf_tcp_raw_check_syncookie_ipv6' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_tcp_raw_check_syncookie_ipv6`

--- a/docs/linux/helper-function/bpf_tcp_raw_gen_syncookie_ipv4.md
+++ b/docs/linux/helper-function/bpf_tcp_raw_gen_syncookie_ipv4.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_tcp_raw_gen_syncookie_ipv4' - eBPF Docs"
+title: "Helper Function 'bpf_tcp_raw_gen_syncookie_ipv4'"
 description: "This page documents the 'bpf_tcp_raw_gen_syncookie_ipv4' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_tcp_raw_gen_syncookie_ipv4`

--- a/docs/linux/helper-function/bpf_tcp_raw_gen_syncookie_ipv6.md
+++ b/docs/linux/helper-function/bpf_tcp_raw_gen_syncookie_ipv6.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_tcp_raw_gen_syncookie_ipv6' - eBPF Docs"
+title: "Helper Function 'bpf_tcp_raw_gen_syncookie_ipv6'"
 description: "This page documents the 'bpf_tcp_raw_gen_syncookie_ipv6' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_tcp_raw_gen_syncookie_ipv6`

--- a/docs/linux/helper-function/bpf_tcp_send_ack.md
+++ b/docs/linux/helper-function/bpf_tcp_send_ack.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_tcp_send_ack' - eBPF Docs"
+title: "Helper Function 'bpf_tcp_send_ack'"
 description: "This page documents the 'bpf_tcp_send_ack' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_tcp_send_ack`

--- a/docs/linux/helper-function/bpf_tcp_sock.md
+++ b/docs/linux/helper-function/bpf_tcp_sock.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_tcp_sock' - eBPF Docs"
+title: "Helper Function 'bpf_tcp_sock'"
 description: "This page documents the 'bpf_tcp_sock' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_tcp_sock`

--- a/docs/linux/helper-function/bpf_this_cpu_ptr.md
+++ b/docs/linux/helper-function/bpf_this_cpu_ptr.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_this_cpu_ptr' - eBPF Docs"
+title: "Helper Function 'bpf_this_cpu_ptr'"
 description: "This page documents the 'bpf_this_cpu_ptr' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_this_cpu_ptr`

--- a/docs/linux/helper-function/bpf_timer_cancel.md
+++ b/docs/linux/helper-function/bpf_timer_cancel.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_timer_cancel' - eBPF Docs"
+title: "Helper Function 'bpf_timer_cancel'"
 description: "This page documents the 'bpf_timer_cancel' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_timer_cancel`

--- a/docs/linux/helper-function/bpf_timer_init.md
+++ b/docs/linux/helper-function/bpf_timer_init.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_timer_init' - eBPF Docs"
+title: "Helper Function 'bpf_timer_init'"
 description: "This page documents the 'bpf_timer_init' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_timer_init`

--- a/docs/linux/helper-function/bpf_timer_set_callback.md
+++ b/docs/linux/helper-function/bpf_timer_set_callback.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_timer_set_callback' - eBPF Docs"
+title: "Helper Function 'bpf_timer_set_callback'"
 description: "This page documents the 'bpf_timer_set_callback' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_timer_set_callback`

--- a/docs/linux/helper-function/bpf_timer_start.md
+++ b/docs/linux/helper-function/bpf_timer_start.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_timer_start' - eBPF Docs"
+title: "Helper Function 'bpf_timer_start'"
 description: "This page documents the 'bpf_timer_start' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_timer_start`

--- a/docs/linux/helper-function/bpf_trace_printk.md
+++ b/docs/linux/helper-function/bpf_trace_printk.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_trace_printk' - eBPF Docs"
+title: "Helper Function 'bpf_trace_printk'"
 description: "This page documents the 'bpf_trace_printk' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_trace_printk`

--- a/docs/linux/helper-function/bpf_trace_vprintk.md
+++ b/docs/linux/helper-function/bpf_trace_vprintk.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_trace_vprintk' - eBPF Docs"
+title: "Helper Function 'bpf_trace_vprintk'"
 description: "This page documents the 'bpf_trace_vprintk' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_trace_vprintk`

--- a/docs/linux/helper-function/bpf_user_ringbuf_drain.md
+++ b/docs/linux/helper-function/bpf_user_ringbuf_drain.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_user_ringbuf_drain' - eBPF Docs"
+title: "Helper Function 'bpf_user_ringbuf_drain'"
 description: "This page documents the 'bpf_user_ringbuf_drain' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_user_ringbuf_drain`

--- a/docs/linux/helper-function/bpf_xdp_adjust_head.md
+++ b/docs/linux/helper-function/bpf_xdp_adjust_head.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_xdp_adjust_head' - eBPF Docs"
+title: "Helper Function 'bpf_xdp_adjust_head'"
 description: "This page documents the 'bpf_xdp_adjust_head' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_xdp_adjust_head`

--- a/docs/linux/helper-function/bpf_xdp_adjust_meta.md
+++ b/docs/linux/helper-function/bpf_xdp_adjust_meta.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_xdp_adjust_meta' - eBPF Docs"
+title: "Helper Function 'bpf_xdp_adjust_meta'"
 description: "This page documents the 'bpf_xdp_adjust_meta' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_xdp_adjust_meta`

--- a/docs/linux/helper-function/bpf_xdp_adjust_tail.md
+++ b/docs/linux/helper-function/bpf_xdp_adjust_tail.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_xdp_adjust_tail' - eBPF Docs"
+title: "Helper Function 'bpf_xdp_adjust_tail'"
 description: "This page documents the 'bpf_xdp_adjust_tail' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_xdp_adjust_tail`

--- a/docs/linux/helper-function/bpf_xdp_get_buff_len.md
+++ b/docs/linux/helper-function/bpf_xdp_get_buff_len.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_xdp_get_buff_len' - eBPF Docs"
+title: "Helper Function 'bpf_xdp_get_buff_len'"
 description: "This page documents the 'bpf_xdp_get_buff_len' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_xdp_get_buff_len`

--- a/docs/linux/helper-function/bpf_xdp_load_bytes.md
+++ b/docs/linux/helper-function/bpf_xdp_load_bytes.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_xdp_load_bytes' - eBPF Docs"
+title: "Helper Function 'bpf_xdp_load_bytes'"
 description: "This page documents the 'bpf_xdp_load_bytes' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_xdp_load_bytes`

--- a/docs/linux/helper-function/bpf_xdp_output.md
+++ b/docs/linux/helper-function/bpf_xdp_output.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_xdp_output' - eBPF Docs"
+title: "Helper Function 'bpf_xdp_output'"
 description: "This page documents the 'bpf_xdp_output' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_xdp_output`

--- a/docs/linux/helper-function/bpf_xdp_store_bytes.md
+++ b/docs/linux/helper-function/bpf_xdp_store_bytes.md
@@ -1,5 +1,5 @@
 ---
-title: "Helper Function 'bpf_xdp_store_bytes' - eBPF Docs"
+title: "Helper Function 'bpf_xdp_store_bytes'"
 description: "This page documents the 'bpf_xdp_store_bytes' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
 # Helper function `bpf_xdp_store_bytes`

--- a/docs/linux/kfuncs/bbr_cwnd_event.md
+++ b/docs/linux/kfuncs/bbr_cwnd_event.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bbr_cwnd_event' - eBPF Docs"
+title: "KFunc 'bbr_cwnd_event'"
 description: "This page documents the 'bbr_cwnd_event' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bbr_cwnd_event`

--- a/docs/linux/kfuncs/bbr_init.md
+++ b/docs/linux/kfuncs/bbr_init.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bbr_init' - eBPF Docs"
+title: "KFunc 'bbr_init'"
 description: "This page documents the 'bbr_init' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bbr_init`

--- a/docs/linux/kfuncs/bbr_main.md
+++ b/docs/linux/kfuncs/bbr_main.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bbr_main' - eBPF Docs"
+title: "KFunc 'bbr_main'"
 description: "This page documents the 'bbr_main' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bbr_main`

--- a/docs/linux/kfuncs/bbr_min_tso_segs.md
+++ b/docs/linux/kfuncs/bbr_min_tso_segs.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bbr_min_tso_segs' - eBPF Docs"
+title: "KFunc 'bbr_min_tso_segs'"
 description: "This page documents the 'bbr_min_tso_segs' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bbr_min_tso_segs`

--- a/docs/linux/kfuncs/bbr_set_state.md
+++ b/docs/linux/kfuncs/bbr_set_state.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bbr_set_state' - eBPF Docs"
+title: "KFunc 'bbr_set_state'"
 description: "This page documents the 'bbr_set_state' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bbr_set_state`

--- a/docs/linux/kfuncs/bbr_sndbuf_expand.md
+++ b/docs/linux/kfuncs/bbr_sndbuf_expand.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bbr_sndbuf_expand' - eBPF Docs"
+title: "KFunc 'bbr_sndbuf_expand'"
 description: "This page documents the 'bbr_sndbuf_expand' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bbr_sndbuf_expand`

--- a/docs/linux/kfuncs/bbr_ssthresh.md
+++ b/docs/linux/kfuncs/bbr_ssthresh.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bbr_ssthresh' - eBPF Docs"
+title: "KFunc 'bbr_ssthresh'"
 description: "This page documents the 'bbr_ssthresh' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bbr_ssthresh`

--- a/docs/linux/kfuncs/bbr_undo_cwnd.md
+++ b/docs/linux/kfuncs/bbr_undo_cwnd.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bbr_undo_cwnd' - eBPF Docs"
+title: "KFunc 'bbr_undo_cwnd'"
 description: "This page documents the 'bbr_undo_cwnd' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bbr_undo_cwnd`

--- a/docs/linux/kfuncs/bpf_cast_to_kern_ctx.md
+++ b/docs/linux/kfuncs/bpf_cast_to_kern_ctx.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cast_to_kern_ctx' - eBPF Docs"
+title: "KFunc 'bpf_cast_to_kern_ctx'"
 description: "This page documents the 'bpf_cast_to_kern_ctx' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cast_to_kern_ctx`

--- a/docs/linux/kfuncs/bpf_cgroup_acquire.md
+++ b/docs/linux/kfuncs/bpf_cgroup_acquire.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cgroup_acquire' - eBPF Docs"
+title: "KFunc 'bpf_cgroup_acquire'"
 description: "This page documents the 'bpf_cgroup_acquire' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cgroup_acquire`

--- a/docs/linux/kfuncs/bpf_cgroup_ancestor.md
+++ b/docs/linux/kfuncs/bpf_cgroup_ancestor.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cgroup_ancestor' - eBPF Docs"
+title: "KFunc 'bpf_cgroup_ancestor'"
 description: "This page documents the 'bpf_cgroup_ancestor' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cgroup_ancestor`

--- a/docs/linux/kfuncs/bpf_cgroup_from_id.md
+++ b/docs/linux/kfuncs/bpf_cgroup_from_id.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cgroup_from_id' - eBPF Docs"
+title: "KFunc 'bpf_cgroup_from_id'"
 description: "This page documents the 'bpf_cgroup_from_id' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cgroup_from_id`

--- a/docs/linux/kfuncs/bpf_cgroup_release.md
+++ b/docs/linux/kfuncs/bpf_cgroup_release.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cgroup_release' - eBPF Docs"
+title: "KFunc 'bpf_cgroup_release'"
 description: "This page documents the 'bpf_cgroup_release' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cgroup_release`

--- a/docs/linux/kfuncs/bpf_cpumask_acquire.md
+++ b/docs/linux/kfuncs/bpf_cpumask_acquire.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_acquire' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_acquire'"
 description: "This page documents the 'bpf_cpumask_acquire' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_acquire`

--- a/docs/linux/kfuncs/bpf_cpumask_and.md
+++ b/docs/linux/kfuncs/bpf_cpumask_and.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_and' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_and'"
 description: "This page documents the 'bpf_cpumask_and' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_and`

--- a/docs/linux/kfuncs/bpf_cpumask_any_and_distribute.md
+++ b/docs/linux/kfuncs/bpf_cpumask_any_and_distribute.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_any_and_distribute' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_any_and_distribute'"
 description: "This page documents the 'bpf_cpumask_any_and_distribute' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_any_and_distribute`

--- a/docs/linux/kfuncs/bpf_cpumask_any_distribute.md
+++ b/docs/linux/kfuncs/bpf_cpumask_any_distribute.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_any_distribute' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_any_distribute'"
 description: "This page documents the 'bpf_cpumask_any_distribute' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_any_distribute`

--- a/docs/linux/kfuncs/bpf_cpumask_clear.md
+++ b/docs/linux/kfuncs/bpf_cpumask_clear.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_clear' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_clear'"
 description: "This page documents the 'bpf_cpumask_clear' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_clear`

--- a/docs/linux/kfuncs/bpf_cpumask_clear_cpu.md
+++ b/docs/linux/kfuncs/bpf_cpumask_clear_cpu.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_clear_cpu' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_clear_cpu'"
 description: "This page documents the 'bpf_cpumask_clear_cpu' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_clear_cpu`

--- a/docs/linux/kfuncs/bpf_cpumask_copy.md
+++ b/docs/linux/kfuncs/bpf_cpumask_copy.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_copy' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_copy'"
 description: "This page documents the 'bpf_cpumask_copy' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_copy`

--- a/docs/linux/kfuncs/bpf_cpumask_create.md
+++ b/docs/linux/kfuncs/bpf_cpumask_create.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_create' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_create'"
 description: "This page documents the 'bpf_cpumask_create' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_create`

--- a/docs/linux/kfuncs/bpf_cpumask_empty.md
+++ b/docs/linux/kfuncs/bpf_cpumask_empty.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_empty' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_empty'"
 description: "This page documents the 'bpf_cpumask_empty' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_empty`

--- a/docs/linux/kfuncs/bpf_cpumask_equal.md
+++ b/docs/linux/kfuncs/bpf_cpumask_equal.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_equal' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_equal'"
 description: "This page documents the 'bpf_cpumask_equal' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_equal`

--- a/docs/linux/kfuncs/bpf_cpumask_first.md
+++ b/docs/linux/kfuncs/bpf_cpumask_first.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_first' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_first'"
 description: "This page documents the 'bpf_cpumask_first' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_first`

--- a/docs/linux/kfuncs/bpf_cpumask_first_and.md
+++ b/docs/linux/kfuncs/bpf_cpumask_first_and.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_first_and' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_first_and'"
 description: "This page documents the 'bpf_cpumask_first_and' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_first_and`

--- a/docs/linux/kfuncs/bpf_cpumask_first_zero.md
+++ b/docs/linux/kfuncs/bpf_cpumask_first_zero.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_first_zero' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_first_zero'"
 description: "This page documents the 'bpf_cpumask_first_zero' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_first_zero`

--- a/docs/linux/kfuncs/bpf_cpumask_full.md
+++ b/docs/linux/kfuncs/bpf_cpumask_full.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_full' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_full'"
 description: "This page documents the 'bpf_cpumask_full' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_full`

--- a/docs/linux/kfuncs/bpf_cpumask_intersects.md
+++ b/docs/linux/kfuncs/bpf_cpumask_intersects.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_intersects' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_intersects'"
 description: "This page documents the 'bpf_cpumask_intersects' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_intersects`

--- a/docs/linux/kfuncs/bpf_cpumask_or.md
+++ b/docs/linux/kfuncs/bpf_cpumask_or.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_or' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_or'"
 description: "This page documents the 'bpf_cpumask_or' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_or`

--- a/docs/linux/kfuncs/bpf_cpumask_release.md
+++ b/docs/linux/kfuncs/bpf_cpumask_release.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_release' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_release'"
 description: "This page documents the 'bpf_cpumask_release' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_release`

--- a/docs/linux/kfuncs/bpf_cpumask_set_cpu.md
+++ b/docs/linux/kfuncs/bpf_cpumask_set_cpu.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_set_cpu' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_set_cpu'"
 description: "This page documents the 'bpf_cpumask_set_cpu' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_set_cpu`

--- a/docs/linux/kfuncs/bpf_cpumask_setall.md
+++ b/docs/linux/kfuncs/bpf_cpumask_setall.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_setall' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_setall'"
 description: "This page documents the 'bpf_cpumask_setall' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_setall`

--- a/docs/linux/kfuncs/bpf_cpumask_subset.md
+++ b/docs/linux/kfuncs/bpf_cpumask_subset.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_subset' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_subset'"
 description: "This page documents the 'bpf_cpumask_subset' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_subset`

--- a/docs/linux/kfuncs/bpf_cpumask_test_and_clear_cpu.md
+++ b/docs/linux/kfuncs/bpf_cpumask_test_and_clear_cpu.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_test_and_clear_cpu' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_test_and_clear_cpu'"
 description: "This page documents the 'bpf_cpumask_test_and_clear_cpu' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_test_and_clear_cpu`

--- a/docs/linux/kfuncs/bpf_cpumask_test_and_set_cpu.md
+++ b/docs/linux/kfuncs/bpf_cpumask_test_and_set_cpu.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_test_and_set_cpu' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_test_and_set_cpu'"
 description: "This page documents the 'bpf_cpumask_test_and_set_cpu' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_test_and_set_cpu`

--- a/docs/linux/kfuncs/bpf_cpumask_test_cpu.md
+++ b/docs/linux/kfuncs/bpf_cpumask_test_cpu.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_test_cpu' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_test_cpu'"
 description: "This page documents the 'bpf_cpumask_test_cpu' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_test_cpu`

--- a/docs/linux/kfuncs/bpf_cpumask_weight.md
+++ b/docs/linux/kfuncs/bpf_cpumask_weight.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_weight' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_weight'"
 description: "This page documents the 'bpf_cpumask_weight' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_weight`

--- a/docs/linux/kfuncs/bpf_cpumask_xor.md
+++ b/docs/linux/kfuncs/bpf_cpumask_xor.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_cpumask_xor' - eBPF Docs"
+title: "KFunc 'bpf_cpumask_xor'"
 description: "This page documents the 'bpf_cpumask_xor' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_cpumask_xor`

--- a/docs/linux/kfuncs/bpf_ct_change_status.md
+++ b/docs/linux/kfuncs/bpf_ct_change_status.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_ct_change_status' - eBPF Docs"
+title: "KFunc 'bpf_ct_change_status'"
 description: "This page documents the 'bpf_ct_change_status' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_ct_change_status`

--- a/docs/linux/kfuncs/bpf_ct_change_timeout.md
+++ b/docs/linux/kfuncs/bpf_ct_change_timeout.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_ct_change_timeout' - eBPF Docs"
+title: "KFunc 'bpf_ct_change_timeout'"
 description: "This page documents the 'bpf_ct_change_timeout' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_ct_change_timeout`

--- a/docs/linux/kfuncs/bpf_ct_insert_entry.md
+++ b/docs/linux/kfuncs/bpf_ct_insert_entry.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_ct_insert_entry' - eBPF Docs"
+title: "KFunc 'bpf_ct_insert_entry'"
 description: "This page documents the 'bpf_ct_insert_entry' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_ct_insert_entry`

--- a/docs/linux/kfuncs/bpf_ct_release.md
+++ b/docs/linux/kfuncs/bpf_ct_release.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_ct_release' - eBPF Docs"
+title: "KFunc 'bpf_ct_release'"
 description: "This page documents the 'bpf_ct_release' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_ct_release`

--- a/docs/linux/kfuncs/bpf_ct_set_nat_info.md
+++ b/docs/linux/kfuncs/bpf_ct_set_nat_info.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_ct_set_nat_info' - eBPF Docs"
+title: "KFunc 'bpf_ct_set_nat_info'"
 description: "This page documents the 'bpf_ct_set_nat_info' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_ct_set_nat_info`

--- a/docs/linux/kfuncs/bpf_ct_set_status.md
+++ b/docs/linux/kfuncs/bpf_ct_set_status.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_ct_set_status' - eBPF Docs"
+title: "KFunc 'bpf_ct_set_status'"
 description: "This page documents the 'bpf_ct_set_status' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_ct_set_status`

--- a/docs/linux/kfuncs/bpf_ct_set_timeout.md
+++ b/docs/linux/kfuncs/bpf_ct_set_timeout.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_ct_set_timeout' - eBPF Docs"
+title: "KFunc 'bpf_ct_set_timeout'"
 description: "This page documents the 'bpf_ct_set_timeout' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_ct_set_timeout`

--- a/docs/linux/kfuncs/bpf_dynptr_adjust.md
+++ b/docs/linux/kfuncs/bpf_dynptr_adjust.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_dynptr_adjust' - eBPF Docs"
+title: "KFunc 'bpf_dynptr_adjust'"
 description: "This page documents the 'bpf_dynptr_adjust' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_dynptr_adjust`

--- a/docs/linux/kfuncs/bpf_dynptr_clone.md
+++ b/docs/linux/kfuncs/bpf_dynptr_clone.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_dynptr_clone' - eBPF Docs"
+title: "KFunc 'bpf_dynptr_clone'"
 description: "This page documents the 'bpf_dynptr_clone' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_dynptr_clone`

--- a/docs/linux/kfuncs/bpf_dynptr_from_skb.md
+++ b/docs/linux/kfuncs/bpf_dynptr_from_skb.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_dynptr_from_skb' - eBPF Docs"
+title: "KFunc 'bpf_dynptr_from_skb'"
 description: "This page documents the 'bpf_dynptr_from_skb' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_dynptr_from_skb`

--- a/docs/linux/kfuncs/bpf_dynptr_from_xdp.md
+++ b/docs/linux/kfuncs/bpf_dynptr_from_xdp.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_dynptr_from_xdp' - eBPF Docs"
+title: "KFunc 'bpf_dynptr_from_xdp'"
 description: "This page documents the 'bpf_dynptr_from_xdp' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_dynptr_from_xdp`

--- a/docs/linux/kfuncs/bpf_dynptr_is_null.md
+++ b/docs/linux/kfuncs/bpf_dynptr_is_null.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_dynptr_is_null' - eBPF Docs"
+title: "KFunc 'bpf_dynptr_is_null'"
 description: "This page documents the 'bpf_dynptr_is_null' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_dynptr_is_null`

--- a/docs/linux/kfuncs/bpf_dynptr_is_rdonly.md
+++ b/docs/linux/kfuncs/bpf_dynptr_is_rdonly.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_dynptr_is_rdonly' - eBPF Docs"
+title: "KFunc 'bpf_dynptr_is_rdonly'"
 description: "This page documents the 'bpf_dynptr_is_rdonly' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_dynptr_is_rdonly`

--- a/docs/linux/kfuncs/bpf_dynptr_size.md
+++ b/docs/linux/kfuncs/bpf_dynptr_size.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_dynptr_size' - eBPF Docs"
+title: "KFunc 'bpf_dynptr_size'"
 description: "This page documents the 'bpf_dynptr_size' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_dynptr_size`

--- a/docs/linux/kfuncs/bpf_dynptr_slice.md
+++ b/docs/linux/kfuncs/bpf_dynptr_slice.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_dynptr_slice' - eBPF Docs"
+title: "KFunc 'bpf_dynptr_slice'"
 description: "This page documents the 'bpf_dynptr_slice' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_dynptr_slice`

--- a/docs/linux/kfuncs/bpf_dynptr_slice_rdwr.md
+++ b/docs/linux/kfuncs/bpf_dynptr_slice_rdwr.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_dynptr_slice_rdwr' - eBPF Docs"
+title: "KFunc 'bpf_dynptr_slice_rdwr'"
 description: "This page documents the 'bpf_dynptr_slice_rdwr' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_dynptr_slice_rdwr`

--- a/docs/linux/kfuncs/bpf_get_file_xattr.md
+++ b/docs/linux/kfuncs/bpf_get_file_xattr.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_get_file_xattr' - eBPF Docs"
+title: "KFunc 'bpf_get_file_xattr'"
 description: "This page documents the 'bpf_get_file_xattr' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_get_file_xattr`

--- a/docs/linux/kfuncs/bpf_get_fsverity_digest.md
+++ b/docs/linux/kfuncs/bpf_get_fsverity_digest.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_get_fsverity_digest' - eBPF Docs"
+title: "KFunc 'bpf_get_fsverity_digest'"
 description: "This page documents the 'bpf_get_fsverity_digest' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_get_fsverity_digest`

--- a/docs/linux/kfuncs/bpf_iter_css_destroy.md
+++ b/docs/linux/kfuncs/bpf_iter_css_destroy.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_css_destroy' - eBPF Docs"
+title: "KFunc 'bpf_iter_css_destroy'"
 description: "This page documents the 'bpf_iter_css_destroy' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_css_destroy`

--- a/docs/linux/kfuncs/bpf_iter_css_new.md
+++ b/docs/linux/kfuncs/bpf_iter_css_new.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_css_new' - eBPF Docs"
+title: "KFunc 'bpf_iter_css_new'"
 description: "This page documents the 'bpf_iter_css_new' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_css_new`

--- a/docs/linux/kfuncs/bpf_iter_css_next.md
+++ b/docs/linux/kfuncs/bpf_iter_css_next.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_css_next' - eBPF Docs"
+title: "KFunc 'bpf_iter_css_next'"
 description: "This page documents the 'bpf_iter_css_next' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_css_next`

--- a/docs/linux/kfuncs/bpf_iter_css_task_destroy.md
+++ b/docs/linux/kfuncs/bpf_iter_css_task_destroy.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_css_task_destroy' - eBPF Docs"
+title: "KFunc 'bpf_iter_css_task_destroy'"
 description: "This page documents the 'bpf_iter_css_task_destroy' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_css_task_destroy`

--- a/docs/linux/kfuncs/bpf_iter_css_task_new.md
+++ b/docs/linux/kfuncs/bpf_iter_css_task_new.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_css_task_new' - eBPF Docs"
+title: "KFunc 'bpf_iter_css_task_new'"
 description: "This page documents the 'bpf_iter_css_task_new' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_css_task_new`

--- a/docs/linux/kfuncs/bpf_iter_css_task_next.md
+++ b/docs/linux/kfuncs/bpf_iter_css_task_next.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_css_task_next' - eBPF Docs"
+title: "KFunc 'bpf_iter_css_task_next'"
 description: "This page documents the 'bpf_iter_css_task_next' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_css_task_next`

--- a/docs/linux/kfuncs/bpf_iter_num_destroy.md
+++ b/docs/linux/kfuncs/bpf_iter_num_destroy.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_num_destroy' - eBPF Docs"
+title: "KFunc 'bpf_iter_num_destroy'"
 description: "This page documents the 'bpf_iter_num_destroy' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_num_destroy`

--- a/docs/linux/kfuncs/bpf_iter_num_new.md
+++ b/docs/linux/kfuncs/bpf_iter_num_new.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_num_new' - eBPF Docs"
+title: "KFunc 'bpf_iter_num_new'"
 description: "This page documents the 'bpf_iter_num_new' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_num_new`

--- a/docs/linux/kfuncs/bpf_iter_num_next.md
+++ b/docs/linux/kfuncs/bpf_iter_num_next.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_num_next' - eBPF Docs"
+title: "KFunc 'bpf_iter_num_next'"
 description: "This page documents the 'bpf_iter_num_next' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_num_next`

--- a/docs/linux/kfuncs/bpf_iter_task_destroy.md
+++ b/docs/linux/kfuncs/bpf_iter_task_destroy.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_task_destroy' - eBPF Docs"
+title: "KFunc 'bpf_iter_task_destroy'"
 description: "This page documents the 'bpf_iter_task_destroy' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_task_destroy`

--- a/docs/linux/kfuncs/bpf_iter_task_new.md
+++ b/docs/linux/kfuncs/bpf_iter_task_new.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_task_new' - eBPF Docs"
+title: "KFunc 'bpf_iter_task_new'"
 description: "This page documents the 'bpf_iter_task_new' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_task_new`

--- a/docs/linux/kfuncs/bpf_iter_task_next.md
+++ b/docs/linux/kfuncs/bpf_iter_task_next.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_task_next' - eBPF Docs"
+title: "KFunc 'bpf_iter_task_next'"
 description: "This page documents the 'bpf_iter_task_next' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_task_next`

--- a/docs/linux/kfuncs/bpf_iter_task_vma_destroy.md
+++ b/docs/linux/kfuncs/bpf_iter_task_vma_destroy.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_task_vma_destroy' - eBPF Docs"
+title: "KFunc 'bpf_iter_task_vma_destroy'"
 description: "This page documents the 'bpf_iter_task_vma_destroy' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_task_vma_destroy`

--- a/docs/linux/kfuncs/bpf_iter_task_vma_new.md
+++ b/docs/linux/kfuncs/bpf_iter_task_vma_new.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_task_vma_new' - eBPF Docs"
+title: "KFunc 'bpf_iter_task_vma_new'"
 description: "This page documents the 'bpf_iter_task_vma_new' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_task_vma_new`

--- a/docs/linux/kfuncs/bpf_iter_task_vma_next.md
+++ b/docs/linux/kfuncs/bpf_iter_task_vma_next.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_iter_task_vma_next' - eBPF Docs"
+title: "KFunc 'bpf_iter_task_vma_next'"
 description: "This page documents the 'bpf_iter_task_vma_next' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_iter_task_vma_next`

--- a/docs/linux/kfuncs/bpf_key_put.md
+++ b/docs/linux/kfuncs/bpf_key_put.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_key_put' - eBPF Docs"
+title: "KFunc 'bpf_key_put'"
 description: "This page documents the 'bpf_key_put' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_key_put`

--- a/docs/linux/kfuncs/bpf_list_pop_back.md
+++ b/docs/linux/kfuncs/bpf_list_pop_back.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_list_pop_back' - eBPF Docs"
+title: "KFunc 'bpf_list_pop_back'"
 description: "This page documents the 'bpf_list_pop_back' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_list_pop_back`

--- a/docs/linux/kfuncs/bpf_list_pop_front.md
+++ b/docs/linux/kfuncs/bpf_list_pop_front.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_list_pop_front' - eBPF Docs"
+title: "KFunc 'bpf_list_pop_front'"
 description: "This page documents the 'bpf_list_pop_front' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_list_pop_front`

--- a/docs/linux/kfuncs/bpf_list_push_back_impl.md
+++ b/docs/linux/kfuncs/bpf_list_push_back_impl.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_list_push_back_impl' - eBPF Docs"
+title: "KFunc 'bpf_list_push_back_impl'"
 description: "This page documents the 'bpf_list_push_back_impl' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_list_push_back_impl`

--- a/docs/linux/kfuncs/bpf_list_push_front_impl.md
+++ b/docs/linux/kfuncs/bpf_list_push_front_impl.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_list_push_front_impl' - eBPF Docs"
+title: "KFunc 'bpf_list_push_front_impl'"
 description: "This page documents the 'bpf_list_push_front_impl' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_list_push_front_impl`

--- a/docs/linux/kfuncs/bpf_lookup_system_key.md
+++ b/docs/linux/kfuncs/bpf_lookup_system_key.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_lookup_system_key' - eBPF Docs"
+title: "KFunc 'bpf_lookup_system_key'"
 description: "This page documents the 'bpf_lookup_system_key' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_lookup_system_key`

--- a/docs/linux/kfuncs/bpf_lookup_user_key.md
+++ b/docs/linux/kfuncs/bpf_lookup_user_key.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_lookup_user_key' - eBPF Docs"
+title: "KFunc 'bpf_lookup_user_key'"
 description: "This page documents the 'bpf_lookup_user_key' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_lookup_user_key`

--- a/docs/linux/kfuncs/bpf_map_sum_elem_count.md
+++ b/docs/linux/kfuncs/bpf_map_sum_elem_count.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_map_sum_elem_count' - eBPF Docs"
+title: "KFunc 'bpf_map_sum_elem_count'"
 description: "This page documents the 'bpf_map_sum_elem_count' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_map_sum_elem_count`

--- a/docs/linux/kfuncs/bpf_obj_drop_impl.md
+++ b/docs/linux/kfuncs/bpf_obj_drop_impl.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_obj_drop_impl' - eBPF Docs"
+title: "KFunc 'bpf_obj_drop_impl'"
 description: "This page documents the 'bpf_obj_drop_impl' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_obj_drop_impl`

--- a/docs/linux/kfuncs/bpf_obj_new_impl.md
+++ b/docs/linux/kfuncs/bpf_obj_new_impl.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_obj_new_impl' - eBPF Docs"
+title: "KFunc 'bpf_obj_new_impl'"
 description: "This page documents the 'bpf_obj_new_impl' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_obj_new_impl`

--- a/docs/linux/kfuncs/bpf_percpu_obj_drop_impl.md
+++ b/docs/linux/kfuncs/bpf_percpu_obj_drop_impl.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_percpu_obj_drop_impl' - eBPF Docs"
+title: "KFunc 'bpf_percpu_obj_drop_impl'"
 description: "This page documents the 'bpf_percpu_obj_drop_impl' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_percpu_obj_drop_impl`

--- a/docs/linux/kfuncs/bpf_percpu_obj_new_impl.md
+++ b/docs/linux/kfuncs/bpf_percpu_obj_new_impl.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_percpu_obj_new_impl' - eBPF Docs"
+title: "KFunc 'bpf_percpu_obj_new_impl'"
 description: "This page documents the 'bpf_percpu_obj_new_impl' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_percpu_obj_new_impl`

--- a/docs/linux/kfuncs/bpf_rbtree_add_impl.md
+++ b/docs/linux/kfuncs/bpf_rbtree_add_impl.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_rbtree_add_impl' - eBPF Docs"
+title: "KFunc 'bpf_rbtree_add_impl'"
 description: "This page documents the 'bpf_rbtree_add_impl' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_rbtree_add_impl`

--- a/docs/linux/kfuncs/bpf_rbtree_first.md
+++ b/docs/linux/kfuncs/bpf_rbtree_first.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_rbtree_first' - eBPF Docs"
+title: "KFunc 'bpf_rbtree_first'"
 description: "This page documents the 'bpf_rbtree_first' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_rbtree_first`

--- a/docs/linux/kfuncs/bpf_rbtree_remove.md
+++ b/docs/linux/kfuncs/bpf_rbtree_remove.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_rbtree_remove' - eBPF Docs"
+title: "KFunc 'bpf_rbtree_remove'"
 description: "This page documents the 'bpf_rbtree_remove' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_rbtree_remove`

--- a/docs/linux/kfuncs/bpf_rcu_read_lock.md
+++ b/docs/linux/kfuncs/bpf_rcu_read_lock.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_rcu_read_lock' - eBPF Docs"
+title: "KFunc 'bpf_rcu_read_lock'"
 description: "This page documents the 'bpf_rcu_read_lock' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_rcu_read_lock`

--- a/docs/linux/kfuncs/bpf_rcu_read_unlock.md
+++ b/docs/linux/kfuncs/bpf_rcu_read_unlock.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_rcu_read_unlock' - eBPF Docs"
+title: "KFunc 'bpf_rcu_read_unlock'"
 description: "This page documents the 'bpf_rcu_read_unlock' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_rcu_read_unlock`

--- a/docs/linux/kfuncs/bpf_rdonly_cast.md
+++ b/docs/linux/kfuncs/bpf_rdonly_cast.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_rdonly_cast' - eBPF Docs"
+title: "KFunc 'bpf_rdonly_cast'"
 description: "This page documents the 'bpf_rdonly_cast' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_rdonly_cast`

--- a/docs/linux/kfuncs/bpf_refcount_acquire_impl.md
+++ b/docs/linux/kfuncs/bpf_refcount_acquire_impl.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_refcount_acquire_impl' - eBPF Docs"
+title: "KFunc 'bpf_refcount_acquire_impl'"
 description: "This page documents the 'bpf_refcount_acquire_impl' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_refcount_acquire_impl`

--- a/docs/linux/kfuncs/bpf_skb_ct_alloc.md
+++ b/docs/linux/kfuncs/bpf_skb_ct_alloc.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_skb_ct_alloc' - eBPF Docs"
+title: "KFunc 'bpf_skb_ct_alloc'"
 description: "This page documents the 'bpf_skb_ct_alloc' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_skb_ct_alloc`

--- a/docs/linux/kfuncs/bpf_skb_ct_lookup.md
+++ b/docs/linux/kfuncs/bpf_skb_ct_lookup.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_skb_ct_lookup' - eBPF Docs"
+title: "KFunc 'bpf_skb_ct_lookup'"
 description: "This page documents the 'bpf_skb_ct_lookup' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_skb_ct_lookup`

--- a/docs/linux/kfuncs/bpf_skb_get_fou_encap.md
+++ b/docs/linux/kfuncs/bpf_skb_get_fou_encap.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_skb_get_fou_encap' - eBPF Docs"
+title: "KFunc 'bpf_skb_get_fou_encap'"
 description: "This page documents the 'bpf_skb_get_fou_encap' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_skb_get_fou_encap`

--- a/docs/linux/kfuncs/bpf_skb_get_xfrm_info.md
+++ b/docs/linux/kfuncs/bpf_skb_get_xfrm_info.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_skb_get_xfrm_info' - eBPF Docs"
+title: "KFunc 'bpf_skb_get_xfrm_info'"
 description: "This page documents the 'bpf_skb_get_xfrm_info' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_skb_get_xfrm_info`

--- a/docs/linux/kfuncs/bpf_skb_set_fou_encap.md
+++ b/docs/linux/kfuncs/bpf_skb_set_fou_encap.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_skb_set_fou_encap' - eBPF Docs"
+title: "KFunc 'bpf_skb_set_fou_encap'"
 description: "This page documents the 'bpf_skb_set_fou_encap' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_skb_set_fou_encap`

--- a/docs/linux/kfuncs/bpf_skb_set_xfrm_info.md
+++ b/docs/linux/kfuncs/bpf_skb_set_xfrm_info.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_skb_set_xfrm_info' - eBPF Docs"
+title: "KFunc 'bpf_skb_set_xfrm_info'"
 description: "This page documents the 'bpf_skb_set_xfrm_info' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_skb_set_xfrm_info`

--- a/docs/linux/kfuncs/bpf_sock_addr_set_sun_path.md
+++ b/docs/linux/kfuncs/bpf_sock_addr_set_sun_path.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_sock_addr_set_sun_path' - eBPF Docs"
+title: "KFunc 'bpf_sock_addr_set_sun_path'"
 description: "This page documents the 'bpf_sock_addr_set_sun_path' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_sock_addr_set_sun_path`

--- a/docs/linux/kfuncs/bpf_sock_destroy.md
+++ b/docs/linux/kfuncs/bpf_sock_destroy.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_sock_destroy' - eBPF Docs"
+title: "KFunc 'bpf_sock_destroy'"
 description: "This page documents the 'bpf_sock_destroy' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_sock_destroy`

--- a/docs/linux/kfuncs/bpf_task_acquire.md
+++ b/docs/linux/kfuncs/bpf_task_acquire.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_task_acquire' - eBPF Docs"
+title: "KFunc 'bpf_task_acquire'"
 description: "This page documents the 'bpf_task_acquire' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_task_acquire`

--- a/docs/linux/kfuncs/bpf_task_from_pid.md
+++ b/docs/linux/kfuncs/bpf_task_from_pid.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_task_from_pid' - eBPF Docs"
+title: "KFunc 'bpf_task_from_pid'"
 description: "This page documents the 'bpf_task_from_pid' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_task_from_pid`

--- a/docs/linux/kfuncs/bpf_task_get_cgroup1.md
+++ b/docs/linux/kfuncs/bpf_task_get_cgroup1.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_task_get_cgroup1' - eBPF Docs"
+title: "KFunc 'bpf_task_get_cgroup1'"
 description: "This page documents the 'bpf_task_get_cgroup1' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_task_get_cgroup1`

--- a/docs/linux/kfuncs/bpf_task_release.md
+++ b/docs/linux/kfuncs/bpf_task_release.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_task_release' - eBPF Docs"
+title: "KFunc 'bpf_task_release'"
 description: "This page documents the 'bpf_task_release' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_task_release`

--- a/docs/linux/kfuncs/bpf_task_under_cgroup.md
+++ b/docs/linux/kfuncs/bpf_task_under_cgroup.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_task_under_cgroup' - eBPF Docs"
+title: "KFunc 'bpf_task_under_cgroup'"
 description: "This page documents the 'bpf_task_under_cgroup' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_task_under_cgroup`

--- a/docs/linux/kfuncs/bpf_throw.md
+++ b/docs/linux/kfuncs/bpf_throw.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_throw' - eBPF Docs"
+title: "KFunc 'bpf_throw'"
 description: "This page documents the 'bpf_throw' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_throw`

--- a/docs/linux/kfuncs/bpf_verify_pkcs7_signature.md
+++ b/docs/linux/kfuncs/bpf_verify_pkcs7_signature.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_verify_pkcs7_signature' - eBPF Docs"
+title: "KFunc 'bpf_verify_pkcs7_signature'"
 description: "This page documents the 'bpf_verify_pkcs7_signature' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_verify_pkcs7_signature`

--- a/docs/linux/kfuncs/bpf_xdp_ct_alloc.md
+++ b/docs/linux/kfuncs/bpf_xdp_ct_alloc.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_xdp_ct_alloc' - eBPF Docs"
+title: "KFunc 'bpf_xdp_ct_alloc'"
 description: "This page documents the 'bpf_xdp_ct_alloc' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_xdp_ct_alloc`

--- a/docs/linux/kfuncs/bpf_xdp_ct_lookup.md
+++ b/docs/linux/kfuncs/bpf_xdp_ct_lookup.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_xdp_ct_lookup' - eBPF Docs"
+title: "KFunc 'bpf_xdp_ct_lookup'"
 description: "This page documents the 'bpf_xdp_ct_lookup' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_xdp_ct_lookup`

--- a/docs/linux/kfuncs/bpf_xdp_get_xfrm_state.md
+++ b/docs/linux/kfuncs/bpf_xdp_get_xfrm_state.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_xdp_get_xfrm_state' - eBPF Docs"
+title: "KFunc 'bpf_xdp_get_xfrm_state'"
 description: "This page documents the 'bpf_xdp_get_xfrm_state' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_xdp_get_xfrm_state`

--- a/docs/linux/kfuncs/bpf_xdp_metadata_rx_hash.md
+++ b/docs/linux/kfuncs/bpf_xdp_metadata_rx_hash.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_xdp_metadata_rx_hash' - eBPF Docs"
+title: "KFunc 'bpf_xdp_metadata_rx_hash'"
 description: "This page documents the 'bpf_xdp_metadata_rx_hash' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_xdp_metadata_rx_hash`

--- a/docs/linux/kfuncs/bpf_xdp_metadata_rx_timestamp.md
+++ b/docs/linux/kfuncs/bpf_xdp_metadata_rx_timestamp.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_xdp_metadata_rx_timestamp' - eBPF Docs"
+title: "KFunc 'bpf_xdp_metadata_rx_timestamp'"
 description: "This page documents the 'bpf_xdp_metadata_rx_timestamp' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_xdp_metadata_rx_timestamp`

--- a/docs/linux/kfuncs/bpf_xdp_metadata_rx_vlan_tag.md
+++ b/docs/linux/kfuncs/bpf_xdp_metadata_rx_vlan_tag.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_xdp_metadata_rx_vlan_tag' - eBPF Docs"
+title: "KFunc 'bpf_xdp_metadata_rx_vlan_tag'"
 description: "This page documents the 'bpf_xdp_metadata_rx_vlan_tag' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_xdp_metadata_rx_vlan_tag`

--- a/docs/linux/kfuncs/bpf_xdp_xfrm_state_release.md
+++ b/docs/linux/kfuncs/bpf_xdp_xfrm_state_release.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'bpf_xdp_xfrm_state_release' - eBPF Docs"
+title: "KFunc 'bpf_xdp_xfrm_state_release'"
 description: "This page documents the 'bpf_xdp_xfrm_state_release' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `bpf_xdp_xfrm_state_release`

--- a/docs/linux/kfuncs/cgroup_rstat_flush.md
+++ b/docs/linux/kfuncs/cgroup_rstat_flush.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'cgroup_rstat_flush' - eBPF Docs"
+title: "KFunc 'cgroup_rstat_flush'"
 description: "This page documents the 'cgroup_rstat_flush' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `cgroup_rstat_flush`

--- a/docs/linux/kfuncs/cgroup_rstat_updated.md
+++ b/docs/linux/kfuncs/cgroup_rstat_updated.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'cgroup_rstat_updated' - eBPF Docs"
+title: "KFunc 'cgroup_rstat_updated'"
 description: "This page documents the 'cgroup_rstat_updated' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `cgroup_rstat_updated`

--- a/docs/linux/kfuncs/crash_kexec.md
+++ b/docs/linux/kfuncs/crash_kexec.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'crash_kexec' - eBPF Docs"
+title: "KFunc 'crash_kexec'"
 description: "This page documents the 'crash_kexec' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `crash_kexec`

--- a/docs/linux/kfuncs/cubictcp_acked.md
+++ b/docs/linux/kfuncs/cubictcp_acked.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'cubictcp_acked' - eBPF Docs"
+title: "KFunc 'cubictcp_acked'"
 description: "This page documents the 'cubictcp_acked' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `cubictcp_acked`

--- a/docs/linux/kfuncs/cubictcp_cong_avoid.md
+++ b/docs/linux/kfuncs/cubictcp_cong_avoid.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'cubictcp_cong_avoid' - eBPF Docs"
+title: "KFunc 'cubictcp_cong_avoid'"
 description: "This page documents the 'cubictcp_cong_avoid' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `cubictcp_cong_avoid`

--- a/docs/linux/kfuncs/cubictcp_cwnd_event.md
+++ b/docs/linux/kfuncs/cubictcp_cwnd_event.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'cubictcp_cwnd_event' - eBPF Docs"
+title: "KFunc 'cubictcp_cwnd_event'"
 description: "This page documents the 'cubictcp_cwnd_event' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `cubictcp_cwnd_event`

--- a/docs/linux/kfuncs/cubictcp_init.md
+++ b/docs/linux/kfuncs/cubictcp_init.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'cubictcp_init' - eBPF Docs"
+title: "KFunc 'cubictcp_init'"
 description: "This page documents the 'cubictcp_init' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `cubictcp_init`

--- a/docs/linux/kfuncs/cubictcp_recalc_ssthresh.md
+++ b/docs/linux/kfuncs/cubictcp_recalc_ssthresh.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'cubictcp_recalc_ssthresh' - eBPF Docs"
+title: "KFunc 'cubictcp_recalc_ssthresh'"
 description: "This page documents the 'cubictcp_recalc_ssthresh' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `cubictcp_recalc_ssthresh`

--- a/docs/linux/kfuncs/cubictcp_state.md
+++ b/docs/linux/kfuncs/cubictcp_state.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'cubictcp_state' - eBPF Docs"
+title: "KFunc 'cubictcp_state'"
 description: "This page documents the 'cubictcp_state' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `cubictcp_state`

--- a/docs/linux/kfuncs/dctcp_cwnd_event.md
+++ b/docs/linux/kfuncs/dctcp_cwnd_event.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'dctcp_cwnd_event' - eBPF Docs"
+title: "KFunc 'dctcp_cwnd_event'"
 description: "This page documents the 'dctcp_cwnd_event' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `dctcp_cwnd_event`

--- a/docs/linux/kfuncs/dctcp_cwnd_undo.md
+++ b/docs/linux/kfuncs/dctcp_cwnd_undo.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'dctcp_cwnd_undo' - eBPF Docs"
+title: "KFunc 'dctcp_cwnd_undo'"
 description: "This page documents the 'dctcp_cwnd_undo' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `dctcp_cwnd_undo`

--- a/docs/linux/kfuncs/dctcp_init.md
+++ b/docs/linux/kfuncs/dctcp_init.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'dctcp_init' - eBPF Docs"
+title: "KFunc 'dctcp_init'"
 description: "This page documents the 'dctcp_init' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `dctcp_init`

--- a/docs/linux/kfuncs/dctcp_ssthresh.md
+++ b/docs/linux/kfuncs/dctcp_ssthresh.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'dctcp_ssthresh' - eBPF Docs"
+title: "KFunc 'dctcp_ssthresh'"
 description: "This page documents the 'dctcp_ssthresh' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `dctcp_ssthresh`

--- a/docs/linux/kfuncs/dctcp_state.md
+++ b/docs/linux/kfuncs/dctcp_state.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'dctcp_state' - eBPF Docs"
+title: "KFunc 'dctcp_state'"
 description: "This page documents the 'dctcp_state' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `dctcp_state`

--- a/docs/linux/kfuncs/dctcp_update_alpha.md
+++ b/docs/linux/kfuncs/dctcp_update_alpha.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'dctcp_update_alpha' - eBPF Docs"
+title: "KFunc 'dctcp_update_alpha'"
 description: "This page documents the 'dctcp_update_alpha' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `dctcp_update_alpha`

--- a/docs/linux/kfuncs/hid_bpf_allocate_context.md
+++ b/docs/linux/kfuncs/hid_bpf_allocate_context.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'hid_bpf_allocate_context' - eBPF Docs"
+title: "KFunc 'hid_bpf_allocate_context'"
 description: "This page documents the 'hid_bpf_allocate_context' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `hid_bpf_allocate_context`

--- a/docs/linux/kfuncs/hid_bpf_attach_prog.md
+++ b/docs/linux/kfuncs/hid_bpf_attach_prog.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'hid_bpf_attach_prog' - eBPF Docs"
+title: "KFunc 'hid_bpf_attach_prog'"
 description: "This page documents the 'hid_bpf_attach_prog' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `hid_bpf_attach_prog`

--- a/docs/linux/kfuncs/hid_bpf_get_data.md
+++ b/docs/linux/kfuncs/hid_bpf_get_data.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'hid_bpf_get_data' - eBPF Docs"
+title: "KFunc 'hid_bpf_get_data'"
 description: "This page documents the 'hid_bpf_get_data' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `hid_bpf_get_data`

--- a/docs/linux/kfuncs/hid_bpf_hw_request.md
+++ b/docs/linux/kfuncs/hid_bpf_hw_request.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'hid_bpf_hw_request' - eBPF Docs"
+title: "KFunc 'hid_bpf_hw_request'"
 description: "This page documents the 'hid_bpf_hw_request' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `hid_bpf_hw_request`

--- a/docs/linux/kfuncs/hid_bpf_release_context.md
+++ b/docs/linux/kfuncs/hid_bpf_release_context.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'hid_bpf_release_context' - eBPF Docs"
+title: "KFunc 'hid_bpf_release_context'"
 description: "This page documents the 'hid_bpf_release_context' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `hid_bpf_release_context`

--- a/docs/linux/kfuncs/tcp_cong_avoid_ai.md
+++ b/docs/linux/kfuncs/tcp_cong_avoid_ai.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'tcp_cong_avoid_ai' - eBPF Docs"
+title: "KFunc 'tcp_cong_avoid_ai'"
 description: "This page documents the 'tcp_cong_avoid_ai' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `tcp_cong_avoid_ai`

--- a/docs/linux/kfuncs/tcp_reno_cong_avoid.md
+++ b/docs/linux/kfuncs/tcp_reno_cong_avoid.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'tcp_reno_cong_avoid' - eBPF Docs"
+title: "KFunc 'tcp_reno_cong_avoid'"
 description: "This page documents the 'tcp_reno_cong_avoid' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `tcp_reno_cong_avoid`

--- a/docs/linux/kfuncs/tcp_reno_ssthresh.md
+++ b/docs/linux/kfuncs/tcp_reno_ssthresh.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'tcp_reno_ssthresh' - eBPF Docs"
+title: "KFunc 'tcp_reno_ssthresh'"
 description: "This page documents the 'tcp_reno_ssthresh' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `tcp_reno_ssthresh`

--- a/docs/linux/kfuncs/tcp_reno_undo_cwnd.md
+++ b/docs/linux/kfuncs/tcp_reno_undo_cwnd.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'tcp_reno_undo_cwnd' - eBPF Docs"
+title: "KFunc 'tcp_reno_undo_cwnd'"
 description: "This page documents the 'tcp_reno_undo_cwnd' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `tcp_reno_undo_cwnd`

--- a/docs/linux/kfuncs/tcp_slow_start.md
+++ b/docs/linux/kfuncs/tcp_slow_start.md
@@ -1,5 +1,5 @@
 ---
-title: "KFunc 'tcp_slow_start' - eBPF Docs"
+title: "KFunc 'tcp_slow_start'"
 description: "This page documents the 'tcp_slow_start' eBPF kfunc, including its defintion, usage, program types that can use it, and examples."
 ---
 # KFunc `tcp_slow_start`

--- a/docs/linux/map-type/BPF_MAP_TYPE_ARRAY.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_ARRAY.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_ARRAY' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_ARRAY'"
 description: "This page documents the 'BPF_MAP_TYPE_ARRAY' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_ARRAY`

--- a/docs/linux/map-type/BPF_MAP_TYPE_ARRAY_OF_MAPS.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_ARRAY_OF_MAPS.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_ARRAY_OF_MAPS' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_ARRAY_OF_MAPS'"
 description: "This page documents the 'BPF_MAP_TYPE_ARRAY_OF_MAPS' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_ARRAY_OF_MAPS`

--- a/docs/linux/map-type/BPF_MAP_TYPE_BLOOM_FILTER.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_BLOOM_FILTER.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_BLOOM_FILTER' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_BLOOM_FILTER'"
 description: "This page documents the 'BPF_MAP_TYPE_BLOOM_FILTER' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_BLOOM_FILTER`

--- a/docs/linux/map-type/BPF_MAP_TYPE_CPUMAP.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_CPUMAP.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_CPUMAP' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_CPUMAP'"
 description: "This page documents the 'BPF_MAP_TYPE_CPUMAP' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_CPUMAP`

--- a/docs/linux/map-type/BPF_MAP_TYPE_DEVMAP.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_DEVMAP.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_DEVMAP' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_DEVMAP'"
 description: "This page documents the 'BPF_MAP_TYPE_DEVMAP' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_DEVMAP`

--- a/docs/linux/map-type/BPF_MAP_TYPE_DEVMAP_HASH.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_DEVMAP_HASH.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_DEVMAP_HASH' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_DEVMAP_HASH'"
 description: "This page documents the 'BPF_MAP_TYPE_DEVMAP_HASH' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_DEVMAP_HASH`

--- a/docs/linux/map-type/BPF_MAP_TYPE_HASH.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_HASH.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_HASH' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_HASH'"
 description: "This page documents the 'BPF_MAP_TYPE_HASH' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_HASH`

--- a/docs/linux/map-type/BPF_MAP_TYPE_LPM_TRIE.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_LPM_TRIE.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_LPM_TRIE' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_LPM_TRIE'"
 description: "This page documents the 'BPF_MAP_TYPE_LPM_TRIE' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_LPM_TRIE`

--- a/docs/linux/map-type/BPF_MAP_TYPE_PERCPU_ARRAY.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_PERCPU_ARRAY.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_PERCPU_ARRAY' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_PERCPU_ARRAY'"
 description: "This page documents the 'BPF_MAP_TYPE_PERCPU_ARRAY' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_PERCPU_ARRAY`

--- a/docs/linux/map-type/BPF_MAP_TYPE_PERCPU_HASH.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_PERCPU_HASH.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_PERCPU_HASH' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_PERCPU_HASH'"
 description: "This page documents the 'BPF_MAP_TYPE_PERCPU_HASH' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_PERCPU_HASH`

--- a/docs/linux/map-type/BPF_MAP_TYPE_PERF_EVENT_ARRAY.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_PERF_EVENT_ARRAY.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_PERF_EVENT_ARRAY' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_PERF_EVENT_ARRAY'"
 description: "This page documents the 'BPF_MAP_TYPE_PERF_EVENT_ARRAY' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_PERF_EVENT_ARRAY`

--- a/docs/linux/map-type/BPF_MAP_TYPE_PROG_ARRAY.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_PROG_ARRAY.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_PROG_ARRAY' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_PROG_ARRAY'"
 description: "This page documents the 'BPF_MAP_TYPE_PROG_ARRAY' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_PROG_ARRAY`

--- a/docs/linux/map-type/BPF_MAP_TYPE_QUEUE.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_QUEUE.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_QUEUE' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_QUEUE'"
 description: "This page documents the 'BPF_MAP_TYPE_QUEUE' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_QUEUE`

--- a/docs/linux/map-type/BPF_MAP_TYPE_REUSEPORT_SOCKARRAY.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_REUSEPORT_SOCKARRAY.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_REUSEPORT_SOCKARRAY' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_REUSEPORT_SOCKARRAY'"
 description: "This page documents the 'BPF_MAP_TYPE_REUSEPORT_SOCKARRAY' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_REUSEPORT_SOCKARRAY`

--- a/docs/linux/map-type/BPF_MAP_TYPE_SOCKHASH.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_SOCKHASH.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_SOCKHASH' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_SOCKHASH'"
 description: "This page documents the 'BPF_MAP_TYPE_SOCKHASH' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_SOCKHASH`

--- a/docs/linux/map-type/BPF_MAP_TYPE_SOCKMAP.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_SOCKMAP.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_SOCKMAP' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_SOCKMAP'"
 description: "This page documents the 'BPF_MAP_TYPE_SOCKMAP' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_SOCKMAP`

--- a/docs/linux/map-type/BPF_MAP_TYPE_STACK.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_STACK.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_STACK' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_STACK'"
 description: "This page documents the 'BPF_MAP_TYPE_STACK' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_STACK`

--- a/docs/linux/map-type/BPF_MAP_TYPE_STACK_TRACE.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_STACK_TRACE.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_STACK_TRACE' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_STACK_TRACE'"
 description: "This page documents the 'BPF_MAP_TYPE_STACK_TRACE' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_STACK_TRACE`

--- a/docs/linux/map-type/BPF_MAP_TYPE_STRUCT_OPS.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_STRUCT_OPS.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_STRUCT_OPS' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_STRUCT_OPS'"
 description: "This page documents the 'BPF_MAP_TYPE_STRUCT_OPS' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_STRUCT_OPS`

--- a/docs/linux/map-type/BPF_MAP_TYPE_XSKMAP.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_XSKMAP.md
@@ -1,5 +1,5 @@
 ---
-title: "Map Type 'BPF_MAP_TYPE_XSKMAP' - eBPF Docs"
+title: "Map Type 'BPF_MAP_TYPE_XSKMAP'"
 description: "This page documents the 'BPF_MAP_TYPE_XSKMAP' eBPF map type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Map type `BPF_MAP_TYPE_XSKMAP`

--- a/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_DEVICE.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_DEVICE.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_CGROUP_DEVICE' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_CGROUP_DEVICE'"
 description: "This page documents the 'BPF_PROG_TYPE_CGROUP_DEVICE' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_CGROUP_DEVICE`

--- a/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SKB.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SKB.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_CGROUP_SKB' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_CGROUP_SKB'"
 description: "This page documents the 'BPF_PROG_TYPE_CGROUP_SKB' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_CGROUP_SKB`

--- a/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SOCK.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SOCK.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_CGROUP_SOCK' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_CGROUP_SOCK'"
 description: "This page documents the 'BPF_PROG_TYPE_CGROUP_SOCK' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_CGROUP_SOCK`

--- a/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SOCKOPT.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SOCKOPT.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_CGROUP_SOCKOPT' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_CGROUP_SOCKOPT'"
 description: "This page documents the 'BPF_PROG_TYPE_CGROUP_SOCKOPT' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_CGROUP_SOCKOPT`

--- a/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SOCK_ADDR.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SOCK_ADDR.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_CGROUP_SOCK_ADDR' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_CGROUP_SOCK_ADDR'"
 description: "This page documents the 'BPF_PROG_TYPE_CGROUP_SOCK_ADDR' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_CGROUP_SOCK_ADDR`

--- a/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SYSCTL.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SYSCTL.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_CGROUP_SYSCTL' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_CGROUP_SYSCTL'"
 description: "This page documents the 'BPF_PROG_TYPE_CGROUP_SYSCTL' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_CGROUP_SYSCTL`

--- a/docs/linux/program-type/BPF_PROG_TYPE_EXT.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_EXT.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_EXT' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_EXT'"
 description: "This page documents the 'BPF_PROG_TYPE_EXT' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_EXT`

--- a/docs/linux/program-type/BPF_PROG_TYPE_FLOW_DISSECTOR.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_FLOW_DISSECTOR.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_FLOW_DISSECTOR' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_FLOW_DISSECTOR'"
 description: "This page documents the 'BPF_PROG_TYPE_FLOW_DISSECTOR' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_FLOW_DISSECTOR`

--- a/docs/linux/program-type/BPF_PROG_TYPE_KPROBE.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_KPROBE.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_KPROBE' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_KPROBE'"
 description: "This page documents the 'BPF_PROG_TYPE_KPROBE' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_KPROBE`

--- a/docs/linux/program-type/BPF_PROG_TYPE_LSM.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_LSM.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_LSM' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_LSM'"
 description: "This page documents the 'BPF_PROG_TYPE_LSM' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_LSM`

--- a/docs/linux/program-type/BPF_PROG_TYPE_PERF_EVENT.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_PERF_EVENT.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_PERF_EVENT' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_PERF_EVENT'"
 description: "This page documents the 'BPF_PROG_TYPE_PERF_EVENT' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_PERF_EVENT`

--- a/docs/linux/program-type/BPF_PROG_TYPE_RAW_TRACEPOINT.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_RAW_TRACEPOINT.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_RAW_TRACEPOINT' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_RAW_TRACEPOINT'"
 description: "This page documents the 'BPF_PROG_TYPE_RAW_TRACEPOINT' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_RAW_TRACEPOINT`

--- a/docs/linux/program-type/BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE'"
 description: "This page documents the 'BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE`

--- a/docs/linux/program-type/BPF_PROG_TYPE_SCHED_CLS.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_SCHED_CLS.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_SCHED_CLS' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_SCHED_CLS'"
 description: "This page documents the 'BPF_PROG_TYPE_SCHED_CLS' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_SCHED_CLS`

--- a/docs/linux/program-type/BPF_PROG_TYPE_SK_LOOKUP.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_SK_LOOKUP.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_SK_LOOKUP' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_SK_LOOKUP'"
 description: "This page documents the 'BPF_PROG_TYPE_SK_LOOKUP' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_SK_LOOKUP`

--- a/docs/linux/program-type/BPF_PROG_TYPE_SK_MSG.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_SK_MSG.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_SK_MSG' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_SK_MSG'"
 description: "This page documents the 'BPF_PROG_TYPE_SK_MSG' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_SK_MSG`

--- a/docs/linux/program-type/BPF_PROG_TYPE_SK_REUSEPORT.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_SK_REUSEPORT.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_SK_REUSEPORT' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_SK_REUSEPORT'"
 description: "This page documents the 'BPF_PROG_TYPE_SK_REUSEPORT' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_SK_REUSEPORT`

--- a/docs/linux/program-type/BPF_PROG_TYPE_SK_SKB.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_SK_SKB.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_SK_SKB' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_SK_SKB'"
 description: "This page documents the 'BPF_PROG_TYPE_SK_SKB' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_SK_SKB`

--- a/docs/linux/program-type/BPF_PROG_TYPE_SOCKET_FILTER.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_SOCKET_FILTER.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_SOCKET_FILTER' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_SOCKET_FILTER'"
 description: "This page documents the 'BPF_PROG_TYPE_SOCKET_FILTER' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_SOCKET_FILTER`

--- a/docs/linux/program-type/BPF_PROG_TYPE_SOCK_OPS.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_SOCK_OPS.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_SOCK_OPS' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_SOCK_OPS'"
 description: "This page documents the 'BPF_PROG_TYPE_SOCK_OPS' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_SOCK_OPS`

--- a/docs/linux/program-type/BPF_PROG_TYPE_TRACEPOINT.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_TRACEPOINT.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_TRACEPOINT' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_TRACEPOINT'"
 description: "This page documents the 'BPF_PROG_TYPE_TRACEPOINT' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_TRACEPOINT`

--- a/docs/linux/program-type/BPF_PROG_TYPE_TRACING.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_TRACING.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_TRACING' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_TRACING'"
 description: "This page documents the 'BPF_PROG_TYPE_TRACING' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_TRACING`

--- a/docs/linux/program-type/BPF_PROG_TYPE_XDP.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_XDP.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'BPF_PROG_TYPE_XDP' - eBPF Docs"
+title: "Program Type 'BPF_PROG_TYPE_XDP'"
 description: "This page documents the 'BPF_PROG_TYPE_XDP' eBPF program type, including its defintion, usage, program types that can use it, and examples."
 ---
 # Program type `BPF_PROG_TYPE_XDP`

--- a/docs/linux/syscall/BPF_BTF_GET_FD_BY_ID.md
+++ b/docs/linux/syscall/BPF_BTF_GET_FD_BY_ID.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_BTF_GET_FD_BY_ID' - eBPF Docs"
+title: "Syscall command 'BPF_BTF_GET_FD_BY_ID'"
 description: "This page documents the 'BPF_BTF_GET_FD_BY_ID' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_BTF_GET_FD_BY_ID` command

--- a/docs/linux/syscall/BPF_BTF_GET_NEXT_ID.md
+++ b/docs/linux/syscall/BPF_BTF_GET_NEXT_ID.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_BTF_GET_NEXT_ID' - eBPF Docs"
+title: "Syscall command 'BPF_BTF_GET_NEXT_ID'"
 description: "This page documents the 'BPF_BTF_GET_NEXT_ID' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_BTF_GET_NEXT_ID` command

--- a/docs/linux/syscall/BPF_BTF_LOAD.md
+++ b/docs/linux/syscall/BPF_BTF_LOAD.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_BTF_LOAD' - eBPF Docs"
+title: "Syscall command 'BPF_BTF_LOAD'"
 description: "This page documents the 'BPF_BTF_LOAD' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_BTF_LOAD` command

--- a/docs/linux/syscall/BPF_ENABLE_STATS.md
+++ b/docs/linux/syscall/BPF_ENABLE_STATS.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_ENABLE_STATS' - eBPF Docs"
+title: "Syscall command 'BPF_ENABLE_STATS'"
 description: "This page documents the 'BPF_ENABLE_STATS' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_ENABLE_STATS` command

--- a/docs/linux/syscall/BPF_ITER_CREATE.md
+++ b/docs/linux/syscall/BPF_ITER_CREATE.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_ITER_CREATE' - eBPF Docs"
+title: "Syscall command 'BPF_ITER_CREATE'"
 description: "This page documents the 'BPF_ITER_CREATE' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_ITER_CREATE` command

--- a/docs/linux/syscall/BPF_LINK_CREATE.md
+++ b/docs/linux/syscall/BPF_LINK_CREATE.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_LINK_CREATE' - eBPF Docs"
+title: "Syscall command 'BPF_LINK_CREATE'"
 description: "This page documents the 'BPF_LINK_CREATE' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_LINK_CREATE` command

--- a/docs/linux/syscall/BPF_LINK_DETACH.md
+++ b/docs/linux/syscall/BPF_LINK_DETACH.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_LINK_DETACH' - eBPF Docs"
+title: "Syscall command 'BPF_LINK_DETACH'"
 description: "This page documents the 'BPF_LINK_DETACH' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_LINK_DETACH` command

--- a/docs/linux/syscall/BPF_LINK_GET_FD_BY_ID.md
+++ b/docs/linux/syscall/BPF_LINK_GET_FD_BY_ID.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_LINK_GET_FD_BY_ID' - eBPF Docs"
+title: "Syscall command 'BPF_LINK_GET_FD_BY_ID'"
 description: "This page documents the 'BPF_LINK_GET_FD_BY_ID' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_LINK_GET_FD_BY_ID` command

--- a/docs/linux/syscall/BPF_LINK_GET_NEXT_ID.md
+++ b/docs/linux/syscall/BPF_LINK_GET_NEXT_ID.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_LINK_GET_NEXT_ID' - eBPF Docs"
+title: "Syscall command 'BPF_LINK_GET_NEXT_ID'"
 description: "This page documents the 'BPF_LINK_GET_NEXT_ID' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_LINK_GET_NEXT_ID` command

--- a/docs/linux/syscall/BPF_LINK_UPDATE.md
+++ b/docs/linux/syscall/BPF_LINK_UPDATE.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_LINK_UPDATE' - eBPF Docs"
+title: "Syscall command 'BPF_LINK_UPDATE'"
 description: "This page documents the 'BPF_LINK_UPDATE' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_LINK_UPDATE` command

--- a/docs/linux/syscall/BPF_MAP_CREATE.md
+++ b/docs/linux/syscall/BPF_MAP_CREATE.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_MAP_CREATE' - eBPF Docs"
+title: "Syscall command 'BPF_MAP_CREATE'"
 description: "This page documents the 'BPF_MAP_CREATE' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_MAP_CREATE` command

--- a/docs/linux/syscall/BPF_MAP_DELETE_BATCH.md
+++ b/docs/linux/syscall/BPF_MAP_DELETE_BATCH.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_MAP_DELETE_BATCH' - eBPF Docs"
+title: "Syscall command 'BPF_MAP_DELETE_BATCH'"
 description: "This page documents the 'BPF_MAP_DELETE_BATCH' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_MAP_DELETE_BATCH` command

--- a/docs/linux/syscall/BPF_MAP_DELETE_ELEM.md
+++ b/docs/linux/syscall/BPF_MAP_DELETE_ELEM.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_MAP_DELETE_ELEM' - eBPF Docs"
+title: "Syscall command 'BPF_MAP_DELETE_ELEM'"
 description: "This page documents the 'BPF_MAP_DELETE_ELEM' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_MAP_DELETE_ELEM` command

--- a/docs/linux/syscall/BPF_MAP_FREEZE.md
+++ b/docs/linux/syscall/BPF_MAP_FREEZE.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_MAP_FREEZE' - eBPF Docs"
+title: "Syscall command 'BPF_MAP_FREEZE'"
 description: "This page documents the 'BPF_MAP_FREEZE' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_MAP_FREEZE` command

--- a/docs/linux/syscall/BPF_MAP_GET_FD_BY_ID.md
+++ b/docs/linux/syscall/BPF_MAP_GET_FD_BY_ID.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_MAP_GET_FD_BY_ID' - eBPF Docs"
+title: "Syscall command 'BPF_MAP_GET_FD_BY_ID'"
 description: "This page documents the 'BPF_MAP_GET_FD_BY_ID' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_MAP_GET_FD_BY_ID` command

--- a/docs/linux/syscall/BPF_MAP_GET_NEXT_ID.md
+++ b/docs/linux/syscall/BPF_MAP_GET_NEXT_ID.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_MAP_GET_NEXT_ID' - eBPF Docs"
+title: "Syscall command 'BPF_MAP_GET_NEXT_ID'"
 description: "This page documents the 'BPF_MAP_GET_NEXT_ID' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_MAP_GET_NEXT_ID` command

--- a/docs/linux/syscall/BPF_MAP_GET_NEXT_KEY.md
+++ b/docs/linux/syscall/BPF_MAP_GET_NEXT_KEY.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_MAP_GET_NEXT_KEY' - eBPF Docs"
+title: "Syscall command 'BPF_MAP_GET_NEXT_KEY'"
 description: "This page documents the 'BPF_MAP_GET_NEXT_KEY' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_MAP_GET_NEXT_KEY` command

--- a/docs/linux/syscall/BPF_MAP_LOOKUP_AND_DELETE_BATCH.md
+++ b/docs/linux/syscall/BPF_MAP_LOOKUP_AND_DELETE_BATCH.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_MAP_LOOKUP_AND_DELETE_BATCH' - eBPF Docs"
+title: "Syscall command 'BPF_MAP_LOOKUP_AND_DELETE_BATCH'"
 description: "This page documents the 'BPF_MAP_LOOKUP_AND_DELETE_BATCH' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_MAP_LOOKUP_AND_DELETE_BATCH` command

--- a/docs/linux/syscall/BPF_MAP_LOOKUP_AND_DELETE_ELEM.md
+++ b/docs/linux/syscall/BPF_MAP_LOOKUP_AND_DELETE_ELEM.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_MAP_LOOKUP_AND_DELETE_ELEM' - eBPF Docs"
+title: "Syscall command 'BPF_MAP_LOOKUP_AND_DELETE_ELEM'"
 description: "This page documents the 'BPF_MAP_LOOKUP_AND_DELETE_ELEM' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_MAP_LOOKUP_AND_DELETE_ELEM` command

--- a/docs/linux/syscall/BPF_MAP_LOOKUP_BATCH.md
+++ b/docs/linux/syscall/BPF_MAP_LOOKUP_BATCH.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_MAP_LOOKUP_BATCH' - eBPF Docs"
+title: "Syscall command 'BPF_MAP_LOOKUP_BATCH'"
 description: "This page documents the 'BPF_MAP_LOOKUP_BATCH' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_MAP_LOOKUP_BATCH` command

--- a/docs/linux/syscall/BPF_MAP_LOOKUP_ELEM.md
+++ b/docs/linux/syscall/BPF_MAP_LOOKUP_ELEM.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_MAP_LOOKUP_ELEM' - eBPF Docs"
+title: "Syscall command 'BPF_MAP_LOOKUP_ELEM'"
 description: "This page documents the 'BPF_MAP_LOOKUP_ELEM' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_MAP_LOOKUP_ELEM` command

--- a/docs/linux/syscall/BPF_MAP_UPDATE_BATCH.md
+++ b/docs/linux/syscall/BPF_MAP_UPDATE_BATCH.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_MAP_UPDATE_BATCH' - eBPF Docs"
+title: "Syscall command 'BPF_MAP_UPDATE_BATCH'"
 description: "This page documents the 'BPF_MAP_UPDATE_BATCH' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_MAP_UPDATE_BATCH` command

--- a/docs/linux/syscall/BPF_MAP_UPDATE_ELEM.md
+++ b/docs/linux/syscall/BPF_MAP_UPDATE_ELEM.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_MAP_UPDATE_ELEM' - eBPF Docs"
+title: "Syscall command 'BPF_MAP_UPDATE_ELEM'"
 description: "This page documents the 'BPF_MAP_UPDATE_ELEM' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_MAP_UPDATE_ELEM` command

--- a/docs/linux/syscall/BPF_OBJ_GET.md
+++ b/docs/linux/syscall/BPF_OBJ_GET.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_OBJ_GET' - eBPF Docs"
+title: "Syscall command 'BPF_OBJ_GET'"
 description: "This page documents the 'BPF_OBJ_GET' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_OBJ_GET` command

--- a/docs/linux/syscall/BPF_OBJ_GET_INFO_BY_FD.md
+++ b/docs/linux/syscall/BPF_OBJ_GET_INFO_BY_FD.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_OBJ_GET_INFO_BY_FD' - eBPF Docs"
+title: "Syscall command 'BPF_OBJ_GET_INFO_BY_FD'"
 description: "This page documents the 'BPF_OBJ_GET_INFO_BY_FD' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_OBJ_GET_INFO_BY_FD` command

--- a/docs/linux/syscall/BPF_OBJ_PIN.md
+++ b/docs/linux/syscall/BPF_OBJ_PIN.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_OBJ_PIN' - eBPF Docs"
+title: "Syscall command 'BPF_OBJ_PIN'"
 description: "This page documents the 'BPF_OBJ_PIN' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_OBJ_PIN` command

--- a/docs/linux/syscall/BPF_PROG_ATTACH.md
+++ b/docs/linux/syscall/BPF_PROG_ATTACH.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_PROG_ATTACH' - eBPF Docs"
+title: "Syscall command 'BPF_PROG_ATTACH'"
 description: "This page documents the 'BPF_PROG_ATTACH' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_PROG_ATTACH` command

--- a/docs/linux/syscall/BPF_PROG_BIND_MAP.md
+++ b/docs/linux/syscall/BPF_PROG_BIND_MAP.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_PROG_BIND_MAP' - eBPF Docs"
+title: "Syscall command 'BPF_PROG_BIND_MAP'"
 description: "This page documents the 'BPF_PROG_BIND_MAP' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_PROG_BIND_MAP` command

--- a/docs/linux/syscall/BPF_PROG_DETACH.md
+++ b/docs/linux/syscall/BPF_PROG_DETACH.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_PROG_DETACH' - eBPF Docs"
+title: "Syscall command 'BPF_PROG_DETACH'"
 description: "This page documents the 'BPF_PROG_DETACH' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_PROG_DETACH` command

--- a/docs/linux/syscall/BPF_PROG_GET_FD_BY_ID.md
+++ b/docs/linux/syscall/BPF_PROG_GET_FD_BY_ID.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_PROG_GET_FD_BY_ID' - eBPF Docs"
+title: "Syscall command 'BPF_PROG_GET_FD_BY_ID'"
 description: "This page documents the 'BPF_PROG_GET_FD_BY_ID' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_PROG_GET_FD_BY_ID` command

--- a/docs/linux/syscall/BPF_PROG_GET_NEXT_ID.md
+++ b/docs/linux/syscall/BPF_PROG_GET_NEXT_ID.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_PROG_GET_NEXT_ID' - eBPF Docs"
+title: "Syscall command 'BPF_PROG_GET_NEXT_ID'"
 description: "This page documents the 'BPF_PROG_GET_NEXT_ID' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_PROG_GET_NEXT_ID` command

--- a/docs/linux/syscall/BPF_PROG_LOAD.md
+++ b/docs/linux/syscall/BPF_PROG_LOAD.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_PROG_LOAD' - eBPF Docs"
+title: "Syscall command 'BPF_PROG_LOAD'"
 description: "This page documents the 'BPF_PROG_LOAD' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_PROG_LOAD` command

--- a/docs/linux/syscall/BPF_PROG_QUERY.md
+++ b/docs/linux/syscall/BPF_PROG_QUERY.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_PROG_QUERY' - eBPF Docs"
+title: "Syscall command 'BPF_PROG_QUERY'"
 description: "This page documents the 'BPF_PROG_QUERY' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_PROG_QUERY` command

--- a/docs/linux/syscall/BPF_PROG_TEST_RUN.md
+++ b/docs/linux/syscall/BPF_PROG_TEST_RUN.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_PROG_TEST_RUN' - eBPF Docs"
+title: "Syscall command 'BPF_PROG_TEST_RUN'"
 description: "This page documents the 'BPF_PROG_TEST_RUN' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_PROG_TEST_RUN` command

--- a/docs/linux/syscall/BPF_RAW_TRACEPOINT_OPEN.md
+++ b/docs/linux/syscall/BPF_RAW_TRACEPOINT_OPEN.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_RAW_TRACEPOINT_OPEN' - eBPF Docs"
+title: "Syscall command 'BPF_RAW_TRACEPOINT_OPEN'"
 description: "This page documents the 'BPF_RAW_TRACEPOINT_OPEN' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_RAW_TRACEPOINT_OPEN` command

--- a/docs/linux/syscall/BPF_TASK_FD_QUERY.md
+++ b/docs/linux/syscall/BPF_TASK_FD_QUERY.md
@@ -1,5 +1,5 @@
 ---
-title: "Syscall command 'BPF_TASK_FD_QUERY' - eBPF Docs"
+title: "Syscall command 'BPF_TASK_FD_QUERY'"
 description: "This page documents the 'BPF_TASK_FD_QUERY' eBPF syscall command, including its defintion, usage, program types that can use it, and examples."
 ---
 # BPF Syscall `BPF_TASK_FD_QUERY` command


### PR DESCRIPTION
Turns out mkdocs add this for you, but I didn't realize until after the original PR merged.