### PR TITLE
Fix titles of bpf_ringbuf functions

### DIFF
--- a/docs/linux/helper-function/bpf_ringbuf_discard.md
+++ b/docs/linux/helper-function/bpf_ringbuf_discard.md
@@ -2,9 +2,9 @@
 title: "Helper Function 'bpf_ringbuf_discard'"
 description: "This page documents the 'bpf_ringbuf_discard' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
-# Helper function `bpf_ringbuf_discard_dynptr`
+# Helper function `bpf_ringbuf_discard`
 
-<!-- [FEATURE_TAG](bpf_ringbuf_discard_dynptr) -->
+<!-- [FEATURE_TAG](bpf_ringbuf_discard) -->
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 

--- a/docs/linux/helper-function/bpf_ringbuf_output.md
+++ b/docs/linux/helper-function/bpf_ringbuf_output.md
@@ -2,9 +2,9 @@
 title: "Helper Function 'bpf_ringbuf_output'"
 description: "This page documents the 'bpf_ringbuf_output' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
-# Helper function `bpf_ringbuf_discard_dynptr`
+# Helper function `bpf_ringbuf_output`
 
-<!-- [FEATURE_TAG](bpf_ringbuf_discard_dynptr) -->
+<!-- [FEATURE_TAG](bpf_ringbuf_output) -->
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 

--- a/docs/linux/helper-function/bpf_ringbuf_query.md
+++ b/docs/linux/helper-function/bpf_ringbuf_query.md
@@ -2,9 +2,9 @@
 title: "Helper Function 'bpf_ringbuf_query'"
 description: "This page documents the 'bpf_ringbuf_query' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
-# Helper function `bpf_ringbuf_discard_dynptr`
+# Helper function `bpf_ringbuf_query`
 
-<!-- [FEATURE_TAG](bpf_ringbuf_discard_dynptr) -->
+<!-- [FEATURE_TAG](bpf_ringbuf_query) -->
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 

--- a/docs/linux/helper-function/bpf_ringbuf_reserve.md
+++ b/docs/linux/helper-function/bpf_ringbuf_reserve.md
@@ -2,9 +2,9 @@
 title: "Helper Function 'bpf_ringbuf_reserve'"
 description: "This page documents the 'bpf_ringbuf_reserve' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
-# Helper function `bpf_ringbuf_discard_dynptr`
+# Helper function `bpf_ringbuf_reserve`
 
-<!-- [FEATURE_TAG](bpf_ringbuf_discard_dynptr) -->
+<!-- [FEATURE_TAG](bpf_ringbuf_discard) -->
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 

--- a/docs/linux/helper-function/bpf_ringbuf_reserve_dynptr.md
+++ b/docs/linux/helper-function/bpf_ringbuf_reserve_dynptr.md
@@ -2,9 +2,9 @@
 title: "Helper Function 'bpf_ringbuf_reserve_dynptr'"
 description: "This page documents the 'bpf_ringbuf_reserve_dynptr' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
-# Helper function `bpf_ringbuf_discard_dynptr`
+# Helper function `bpf_ringbuf_reserve_dynptr`
 
-<!-- [FEATURE_TAG](bpf_ringbuf_discard_dynptr) -->
+<!-- [FEATURE_TAG](bpf_ringbuf_reserve_dynptr) -->
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 

--- a/docs/linux/helper-function/bpf_ringbuf_submit.md
+++ b/docs/linux/helper-function/bpf_ringbuf_submit.md
@@ -2,9 +2,9 @@
 title: "Helper Function 'bpf_ringbuf_submit'"
 description: "This page documents the 'bpf_ringbuf_submit' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
-# Helper function `bpf_ringbuf_discard_dynptr`
+# Helper function `bpf_ringbuf_submit`
 
-<!-- [FEATURE_TAG](bpf_ringbuf_discard_dynptr) -->
+<!-- [FEATURE_TAG](bpf_ringbuf_submit) -->
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 

--- a/docs/linux/helper-function/bpf_ringbuf_submit_dynptr.md
+++ b/docs/linux/helper-function/bpf_ringbuf_submit_dynptr.md
@@ -2,9 +2,9 @@
 title: "Helper Function 'bpf_ringbuf_submit_dynptr'"
 description: "This page documents the 'bpf_ringbuf_submit_dynptr' eBPF helper function, including its defintion, usage, program types that can use it, and examples."
 ---
-# Helper function `bpf_ringbuf_discard_dynptr`
+# Helper function `bpf_ringbuf_submit_dynptr`
 
-<!-- [FEATURE_TAG](bpf_ringbuf_discard_dynptr) -->
+<!-- [FEATURE_TAG](bpf_ringbuf_submit_dynptr) -->
 [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
 <!-- [/FEATURE_TAG] -->
 


### PR DESCRIPTION
Titles of bpf_ringbuf function pages are all the same; now they are proper. 