### PR TITLE
Update ringbuf helper version links

### DIFF
--- a/docs/linux/helper-function/bpf_ringbuf_discard.md
+++ b/docs/linux/helper-function/bpf_ringbuf_discard.md
@@ -5,7 +5,7 @@ description: "This page documents the 'bpf_ringbuf_discard' eBPF helper function
 # Helper function `bpf_ringbuf_discard`
 
 <!-- [FEATURE_TAG](bpf_ringbuf_discard) -->
-[:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
+[:octicons-tag-24: v5.8](https://github.com/torvalds/linux/commit/457f44363a8894135c85b7a9afd2bd8196db24ab)
 <!-- [/FEATURE_TAG] -->
 
 ## Definition

--- a/docs/linux/helper-function/bpf_ringbuf_output.md
+++ b/docs/linux/helper-function/bpf_ringbuf_output.md
@@ -5,7 +5,7 @@ description: "This page documents the 'bpf_ringbuf_output' eBPF helper function,
 # Helper function `bpf_ringbuf_output`
 
 <!-- [FEATURE_TAG](bpf_ringbuf_output) -->
-[:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
+[:octicons-tag-24: v5.8](https://github.com/torvalds/linux/commit/457f44363a8894135c85b7a9afd2bd8196db24ab)
 <!-- [/FEATURE_TAG] -->
 
 ## Definition

--- a/docs/linux/helper-function/bpf_ringbuf_query.md
+++ b/docs/linux/helper-function/bpf_ringbuf_query.md
@@ -5,7 +5,7 @@ description: "This page documents the 'bpf_ringbuf_query' eBPF helper function, 
 # Helper function `bpf_ringbuf_query`
 
 <!-- [FEATURE_TAG](bpf_ringbuf_query) -->
-[:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
+[:octicons-tag-24: v5.8](https://github.com/torvalds/linux/commit/457f44363a8894135c85b7a9afd2bd8196db24ab)
 <!-- [/FEATURE_TAG] -->
 
 ## Definition

--- a/docs/linux/helper-function/bpf_ringbuf_reserve.md
+++ b/docs/linux/helper-function/bpf_ringbuf_reserve.md
@@ -5,7 +5,7 @@ description: "This page documents the 'bpf_ringbuf_reserve' eBPF helper function
 # Helper function `bpf_ringbuf_reserve`
 
 <!-- [FEATURE_TAG](bpf_ringbuf_discard) -->
-[:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
+[:octicons-tag-24: v5.8](https://github.com/torvalds/linux/commit/457f44363a8894135c85b7a9afd2bd8196db24ab)
 <!-- [/FEATURE_TAG] -->
 
 ## Definition

--- a/docs/linux/helper-function/bpf_ringbuf_submit.md
+++ b/docs/linux/helper-function/bpf_ringbuf_submit.md
@@ -5,7 +5,7 @@ description: "This page documents the 'bpf_ringbuf_submit' eBPF helper function,
 # Helper function `bpf_ringbuf_submit`
 
 <!-- [FEATURE_TAG](bpf_ringbuf_submit) -->
-[:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/bc34dee65a65e9c920c420005b8a43f2a721a458)
+[:octicons-tag-24: v5.8](https://github.com/torvalds/linux/commit/457f44363a8894135c85b7a9afd2bd8196db24ab)
 <!-- [/FEATURE_TAG] -->
 
 ## Definition


### PR DESCRIPTION
PR #18 updated the symbols and headers of the ringbuf helper functions which were incorrect before. This commit follows up by regenerating the hyperlinks of the version number links.