### PR TITLE
program-type/BPF_PROG_TYPE_XDP.md: Add max MTU table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,4 +45,5 @@ generate-docs:
 	cd ${REPODIR}/tools/helper-ref-gen; go run main.go --project-root "${REPODIR}"
 	cd ${REPODIR}/tools/feature-tag-gen; go run main.go --project-root "${REPODIR}"
 	cd ${REPODIR}/tools/kfunc-gen; go run main.go --project-root "${REPODIR}"
+	cd ${REPODIR}/tools/mtu-calc; go run . --project-root "${REPODIR}"
 	cd ${REPODIR}/tools/helper-def-scraper; go run main.go --helper-path "${REPODIR}/docs/linux/helper-function"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ebpf.io/docs
 
-go 1.19
+go 1.22
 
 require (
 	github.com/cilium/ebpf v0.12.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,14 +33,16 @@ markdown_extensions:
   - pymdownx.superfences
   - footnotes
   - attr_list
-  - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.inlinehilite
   - abbr
   - pymdownx.snippets
   - attr_list
   - md_in_html
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.tabbed:
+      alternate_style: true
 
 plugins:
   - search:

--- a/tools/mtu-calc/const.go
+++ b/tools/mtu-calc/const.go
@@ -1,0 +1,11 @@
+package main
+
+const (
+	ETH_ALEN     = 6
+	ETH_HLEN     = 14
+	ETH_FCS_LEN  = 4
+	ETH_DATA_LEN = 1500
+
+	VLAN_HLEN     = 4
+	VLAN_ETH_HLEN = 18
+)

--- a/tools/mtu-calc/drivers.go
+++ b/tools/mtu-calc/drivers.go
@@ -1,0 +1,452 @@
+package main
+
+import "math"
+
+var drivers = map[string]func(vars) int{
+	"veth":               calcVethMTU,
+	"tun":                calcTunMTU,
+	"virtio_net":         calcVirtioNetMTU,
+	"xen-netfront":       calcXenNetfrontMTU,
+	"Amazon ENA":         calcEnaMTU,
+	"Aquantia Atlantic":  calcAQMTU,
+	"Broadcom BNXT":      calcBNXTMTU,
+	"Cavium Thunder":     calcNICVFMTU,
+	"Engelder":           calcTsnepMTU,
+	"Freescale fec_enet": calcFecMTU,
+	"Freescale DPAA":     calcDPAAMTU,
+	"Freescale DPAA2":    calcDPAA2MTU,
+	"Freescale ENETC":    calcENETCMTU,
+	"Fungible Funeth":    calcFunMTU,
+	"Google GVE":         calcGVEMTU,
+	"Intel i40e":         calcI40EMTU,
+	"Intel ice":          calcICEMTU,
+	"Intel igb":          calcIGBMTU,
+	"Intel igc":          calcIGCMTU,
+	"Intel ixgbe":        calcIXGBE,
+	"Intel ixgbevf":      calcIXGBEVF,
+	"Marvell mvneta":     calcMVNetaMTU,
+	"Marvell mvpp2":      calcMVPP2MTU,
+	"Marvell OcteonTX2":  calcOTX2MTU,
+	"Mediatek MTK":       calcMtkMTU,
+	"Mellanox mlx4":      calcMLX4MTU,
+	"Mellanox mlx5":      calcMLX5MTU,
+	"Microchip LAN966x":  calcLan966xMTU,
+	"Microsoft Mana":     calcManaMTU,
+	"Netronome NFP":      calcNFPMTU,
+	"Pensando Ionic":     calcIonicMTU,
+	"QLogic qede":        calcQedeMTU,
+	"Solarflare SFP":     calcSFPMTU,
+	"Socionext Netsec":   calcNetsecMTU,
+	"STMicro stmmac":     calcStmmacMTU,
+	"TI CPSW":            calcCPSWMTU,
+	"Hyper-V Netvsc":     calcNetvscMTU,
+	"VMware vmxnet3":     calcVmxnet3MTU,
+}
+
+func calcVethMTU(v vars) int {
+	vethXDPHeadroom := v.XDPPacketheadroom + v.NetIPAlign()
+	maxMTU := macroSKBWithOverhead(v.PageSize-vethXDPHeadroom, v) - v.PeerHardHeaderLen
+
+	if !v.Frags {
+		return maxMTU
+	}
+
+	return maxMTU + v.PageSize*v.MaxSKBFrags()
+}
+
+func calcTunMTU(v vars) int {
+	return ETH_DATA_LEN
+}
+
+func calcVirtioNetMTU(v vars) int {
+	const virtioXDPHeadroom = 256
+	room := macroSKBDataAlign(virtioXDPHeadroom+v.SizeOfSKBSharedInfo(), v)
+	maxSz := v.PageSize - room - ETH_HLEN
+
+	if v.Frags {
+		return math.MaxInt
+	}
+
+	return maxSz
+}
+
+func calcXenNetfrontMTU(v vars) int {
+	const xenPageSize = 1 << 12
+	maxMTU := xenPageSize - v.XDPPacketheadroom
+
+	return maxMTU
+}
+
+func calcEnaMTU(v vars) int {
+	const SZ_16K = 0x4000
+	var enaPageSize int
+	if v.PageSize > SZ_16K {
+		enaPageSize = SZ_16K
+	} else {
+		enaPageSize = v.PageSize
+	}
+
+	return enaPageSize - ETH_HLEN - ETH_FCS_LEN - VLAN_HLEN - v.XDPPacketheadroom -
+		macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v)
+}
+
+func calcAQMTU(v vars) int {
+	if v.Frags {
+		return math.MaxInt
+	}
+
+	const AQ_CFG_RX_FRAME_MAX = 2 * 1024
+	return AQ_CFG_RX_FRAME_MAX
+}
+
+func calcBNXTMTU(v vars) int {
+	if v.Frags {
+		return math.MaxInt
+	}
+
+	BNXT_MAX_PAGE_MODE_MTU_SBUF := v.PageSize - VLAN_ETH_HLEN - v.NetIPAlign() - v.XDPPacketheadroom
+	BNXT_MAX_PAGE_MODE_MTU := BNXT_MAX_PAGE_MODE_MTU_SBUF - macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v)
+
+	return BNXT_MAX_PAGE_MODE_MTU
+}
+
+func calcNICVFMTU(v vars) int {
+	const MAX_XDP_MTU = 1530 - ETH_HLEN - VLAN_HLEN*2
+	return MAX_XDP_MTU
+}
+
+func calcTsnepMTU(v vars) int {
+	return math.MaxInt
+}
+
+func calcFecMTU(v vars) int {
+	return math.MaxInt
+}
+
+func calcDPAAMTU(v vars) int {
+	const (
+		DPAA_A050385_ALIGN      = 256
+		DPAA_TIME_STAMP_SIZE    = 8
+		DPAA_HASH_RESULTS_SIZE  = 8
+		DPAA_PARSE_RESULTS_SIZE = 18 // sizeof(struct fman_prs_result)
+		DPAA_HWA_SIZE           = DPAA_PARSE_RESULTS_SIZE + DPAA_TIME_STAMP_SIZE + DPAA_HASH_RESULTS_SIZE
+	)
+	const bpRawSize = 4096
+
+	dpaaBPSize := func(rawSize int) int {
+		if v.ERRATUM_A050385 {
+			return macroSKBWithOverhead(rawSize, v) & ^(DPAA_A050385_ALIGN - 1)
+		}
+		return macroSKBWithOverhead(rawSize, v)
+	}
+	dpaaGetHeadroom := func(priv_data_size int) int {
+		headroom := priv_data_size + DPAA_HWA_SIZE
+		if v.ERRATUM_A050385 {
+			headroom = v.XDPPacketheadroom
+		}
+
+		DPAA_FD_RX_DATA_ALIGNMENT := 16
+		if v.ERRATUM_A050385 {
+			DPAA_FD_RX_DATA_ALIGNMENT = 64
+		}
+
+		return macroAlign(headroom, DPAA_FD_RX_DATA_ALIGNMENT)
+	}
+
+	bpSize := dpaaBPSize(bpRawSize)
+	rxHeadroom := dpaaGetHeadroom(0000)
+	maxConfigSize := bpSize - rxHeadroom
+
+	return maxConfigSize - (VLAN_ETH_HLEN + ETH_FCS_LEN)
+}
+
+func calcDPAA2MTU(v vars) int {
+	// TODO: figure out typical priv->tx_data_offset which is recieved from the NIC
+	// without it we can't calculate the MTU
+	return 0
+}
+
+func calcENETCMTU(v vars) int {
+	return math.MaxInt
+}
+
+func calcFunMTU(v vars) int {
+	const FUN_XDP_HEADROOM = 192
+	FUN_RX_TAILROOM := macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v)
+	return v.PageSize - FUN_XDP_HEADROOM - VLAN_ETH_HLEN - FUN_RX_TAILROOM
+}
+
+func calcGVEMTU(v vars) int {
+	const GVE_DEFAULT_RX_BUFFER_SIZE = 2048
+	const GVE_RX_PAD = 2
+	return GVE_DEFAULT_RX_BUFFER_SIZE - ETH_HLEN - GVE_RX_PAD
+}
+
+func calcI40EMTU(v vars) int {
+	const (
+		I40E_RXBUFFER_2048          = 2048
+		I40E_RXBUFFER_3072          = 3072
+		I40E_MAX_CHAINED_RX_BUFFERS = 5
+		I40E_MAX_RXBUFFER           = 9728
+		I40E_PACKET_HDR_PAD         = ETH_HLEN + ETH_FCS_LEN + (VLAN_HLEN * 2)
+	)
+
+	var vsiRXBufLen int
+	if v.I40ELegacyRXENA {
+		vsiRXBufLen = macroSKBWithOverhead(I40E_RXBUFFER_2048, v)
+	} else {
+		if v.PageSize < 8192 {
+			vsiRXBufLen = I40E_RXBUFFER_3072
+		} else {
+			vsiRXBufLen = I40E_RXBUFFER_2048
+		}
+	}
+
+	chainLen := 1
+	if v.Frags {
+		chainLen = I40E_MAX_CHAINED_RX_BUFFERS
+	}
+
+	frameSize := min(vsiRXBufLen*chainLen, I40E_MAX_RXBUFFER)
+	return frameSize - I40E_PACKET_HDR_PAD
+}
+
+func calcICEMTU(v vars) int {
+	const (
+		ICE_RXBUF_1664      = 1664
+		ICE_RXBUF_3072      = 3072
+		ICE_ETH_PKT_HDR_PAD = ETH_HLEN + ETH_FCS_LEN + (VLAN_HLEN * 2)
+	)
+
+	var maxFrameSize int
+	if v.ICELegacyRX {
+		maxFrameSize = ICE_RXBUF_1664
+	} else {
+		maxFrameSize = ICE_RXBUF_3072
+	}
+
+	return maxFrameSize - ICE_ETH_PKT_HDR_PAD
+}
+
+func calcIGBMTU(v vars) int {
+	const (
+		IGB_RXBUFFER_1536   = 1536
+		IGB_RXBUFFER_2048   = 2048
+		IGB_RXBUFFER_3072   = 3072
+		IGB_ETH_PKT_HDR_PAD = ETH_HLEN + ETH_FCS_LEN + (VLAN_HLEN * 2)
+	)
+	IGB_MAX_FRAME_BUILD_SKB := IGB_RXBUFFER_1536 - v.NetIPAlign()
+
+	var rxBufSize int
+	if v.PageSize < 8192 {
+		if v.IGBUseLargeRing {
+			rxBufSize = IGB_RXBUFFER_3072
+		} else if v.IGBUseSKB {
+			rxBufSize = IGB_MAX_FRAME_BUILD_SKB
+		} else {
+			rxBufSize = IGB_RXBUFFER_2048
+		}
+	} else {
+		rxBufSize = IGB_RXBUFFER_2048
+	}
+
+	return rxBufSize - IGB_ETH_PKT_HDR_PAD
+}
+
+func calcIGCMTU(v vars) int {
+	return ETH_DATA_LEN
+}
+
+func calcIXGBE(v vars) int {
+	const (
+		IXGBE_RXBUFFER_1536 = 1536
+		IXGBE_RXBUFFER_2K   = 2048
+		IXGBE_RXBUFFER_3K   = 3072
+	)
+	IXGBE_MAX_2K_FRAME_BUILD_SKB := IXGBE_RXBUFFER_1536 - v.NetIPAlign()
+
+	var rxBufSize int
+	if v.IXGBRX3kBuffer {
+		rxBufSize = IXGBE_RXBUFFER_3K
+	} else {
+		if v.PageSize < 8192 {
+			if v.IXGBUseSKB {
+				rxBufSize = IXGBE_MAX_2K_FRAME_BUILD_SKB
+			} else {
+				rxBufSize = IXGBE_RXBUFFER_2K
+			}
+		} else {
+			rxBufSize = IXGBE_RXBUFFER_2K
+		}
+
+	}
+	return rxBufSize - (ETH_HLEN + ETH_FCS_LEN + VLAN_HLEN)
+}
+
+func calcIXGBEVF(v vars) int {
+	const (
+		IXGBEVF_RXBUFFER_1536 = 1536
+		IXGBEVF_RXBUFFER_2048 = 2048
+		IXGBEVF_RXBUFFER_3072 = 3072
+	)
+
+	var IXGBEVF_MAX_FRAME_BUILD_SKB int
+	if v.PageSize < 8192 {
+		IXGBEVF_SKB_PAD := v.NetSKBPad() + v.NetIPAlign()
+		IXGBEVF_MAX_FRAME_BUILD_SKB = macroSKBWithOverhead(IXGBEVF_RXBUFFER_2048, v) - IXGBEVF_SKB_PAD
+	} else {
+		IXGBEVF_MAX_FRAME_BUILD_SKB = IXGBEVF_RXBUFFER_2048
+	}
+
+	rxBufSize := func() int {
+		if v.PageSize < 8192 {
+			if v.IXGBEVLargeBuffer {
+				return IXGBEVF_RXBUFFER_3072
+			}
+
+			if v.IXGBEVFUseSKB {
+				return IXGBEVF_MAX_FRAME_BUILD_SKB
+			}
+
+		}
+		return IXGBEVF_RXBUFFER_2048
+	}()
+
+	return rxBufSize - (ETH_HLEN + ETH_FCS_LEN + VLAN_HLEN)
+}
+
+func calcMVNetaMTU(v vars) int {
+	if v.Frags {
+		return math.MaxInt
+	}
+
+	MVNETA_SKB_HEADROOM := macroAlign(max(v.NetSKBPad(), v.XDPPacketheadroom), 8)
+	MVNETA_SKB_PAD := macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v) + MVNETA_SKB_HEADROOM
+	return v.PageSize - MVNETA_SKB_PAD
+}
+
+func calcMVPP2MTU(v vars) int {
+	MVPP2_SKB_HEADROOM := min(max(v.XDPPacketheadroom, v.NetSKBPad()), 224)
+	MVPP2_SKB_SHINFO_SIZE := macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v)
+	return v.PageSize - MVPP2_SKB_SHINFO_SIZE - MVPP2_SKB_HEADROOM
+}
+
+func calcOTX2MTU(v vars) int {
+	OTX2_ETH_HLEN := VLAN_ETH_HLEN + VLAN_HLEN
+	return 1530 - OTX2_ETH_HLEN
+}
+
+func calcMtkMTU(v vars) int {
+	MTK_PP_HEADROOM := v.XDPPacketheadroom
+	MTK_PP_PAD := MTK_PP_HEADROOM + macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v)
+	return v.PageSize - MTK_PP_PAD
+}
+
+func calcMLX4MTU(v vars) int {
+	return v.PageSize - ETH_HLEN - (2 * VLAN_HLEN) - v.XDPPacketheadroom - macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v)
+}
+
+func calcMLX5MTU(v vars) int {
+	if v.Frags {
+		return math.MaxInt
+	}
+
+	headroom := 256
+	hwmtu := v.PageSize - headroom
+	MLX5E_ETH_HARD_MTU := (ETH_HLEN + VLAN_HLEN + ETH_FCS_LEN)
+	return hwmtu - macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v) - MLX5E_ETH_HARD_MTU
+}
+
+func calcLan966xMTU(v vars) int {
+	return math.MaxInt
+}
+
+func calcManaMTU(v vars) int {
+	MANA_RXBUF_PAD := macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v) + ETH_HLEN
+	return v.PageSize - MANA_RXBUF_PAD - v.XDPPacketheadroom
+}
+
+func calcNFPMTU(v vars) int {
+	return v.PageSize
+}
+
+func calcIonicMTU(v vars) int {
+	return v.PageSize - (VLAN_ETH_HLEN + v.XDPPacketheadroom + macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v))
+}
+
+func calcQedeMTU(v vars) int {
+	return math.MaxInt
+}
+
+func calcSFPMTUModel(model SFCModel) func(v vars) int {
+	return func(v vars) int {
+		v.SFCModel = model
+		return calcSFPMTU(v)
+	}
+}
+
+func calcSFPMTU(v vars) int {
+	var rxPrefixSize int
+	switch v.SFCModel {
+	case hunt:
+		rxPrefixSize = 14
+	case ef100:
+		rxPrefixSize = 22
+	case falcon_a1:
+		rxPrefixSize = 0
+	case falcon_b0:
+		rxPrefixSize = 16
+	case siena_a0:
+		rxPrefixSize = 16
+	}
+
+	var rxBufferPadding int
+	switch v.SFCModel {
+	case falcon_a1:
+		rxBufferPadding = 0x24
+	default:
+		rxBufferPadding = 0
+	}
+
+	var rxIPAlign int
+	if v.NetIPAlign() != 0 {
+		rxIPAlign = rxPrefixSize + v.NetIPAlign()
+	}
+
+	EFX_FRAME_PAD := 16
+	maxFrameLen := func(mtu int) int {
+		return (macroAlign(mtu+ETH_HLEN+VLAN_HLEN+ETH_FCS_LEN+EFX_FRAME_PAD, 8))
+	}
+
+	headroom := 128
+	tailroom := macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v)
+	sizeOfRXPageSize := v.SMPCacheBytes() // sizeof(struct efx_rx_page_state) (aligned to cache line)
+	overhead := maxFrameLen(0) + sizeOfRXPageSize + rxPrefixSize + rxBufferPadding +
+		rxIPAlign + tailroom + headroom
+
+	return v.PageSize - overhead
+}
+
+func calcNetsecMTU(v vars) int {
+	return ETH_DATA_LEN
+}
+
+func calcStmmacMTU(v vars) int {
+	return ETH_DATA_LEN
+}
+
+func calcCPSWMTU(v vars) int {
+	return math.MaxInt
+}
+
+func calcNetvscMTU(v vars) int {
+	const NETVSC_XDP_HDRM = 256
+	return v.PageSize - (ETH_HLEN + NETVSC_XDP_HDRM + macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v))
+}
+
+func calcVmxnet3MTU(v vars) int {
+	VMXNET3_XDP_HEADROOM := v.XDPPacketheadroom + v.NetIPAlign()
+	VMXNET3_XDP_RX_TAILROOM := macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v)
+	VMXNET3_XDP_MAX_FRSIZE := v.PageSize - VMXNET3_XDP_HEADROOM - VMXNET3_XDP_RX_TAILROOM
+	return VMXNET3_XDP_MAX_FRSIZE - ETH_HLEN - 2*VLAN_HLEN - ETH_FCS_LEN
+}

--- a/tools/mtu-calc/macro.go
+++ b/tools/mtu-calc/macro.go
@@ -1,0 +1,13 @@
+package main
+
+func macroSKBWithOverhead(x int, v vars) int {
+	return x - macroSKBDataAlign(v.SizeOfSKBSharedInfo(), v)
+}
+
+func macroSKBDataAlign(x int, v vars) int {
+	return macroAlign(x, v.SMPCacheBytes())
+}
+
+func macroAlign(x int, align int) int {
+	return (x + align - 1) & ^(align - 1)
+}

--- a/tools/mtu-calc/main.go
+++ b/tools/mtu-calc/main.go
@@ -1,0 +1,123 @@
+// This tool looks for markers in doc pages that request the insertion of a version tag for a given "feature"
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+)
+
+var projectroot = flag.String("project-root", "", "Root of the project")
+
+const (
+	programsDir = "docs/linux/program-type"
+)
+
+var mtuTableStartRegex = regexp.MustCompile(`<!-- \[MTU_TABLE\] -->`)
+
+const mtuTableMarkerStop = "<!-- [/MTU_TABLE] -->"
+
+func main() {
+	flag.Parse()
+
+	if projectroot == nil || *projectroot == "" {
+		fmt.Fprintln(os.Stderr, "Missing 'project-root' flag")
+		return
+	}
+
+	if err := mainE(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+}
+
+func mainE() error {
+	entries, err := os.ReadDir(path.Join(*projectroot, programsDir))
+	if err != nil {
+		return fmt.Errorf("Read dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		filePath := path.Join(*projectroot, programsDir, entry.Name())
+		err = processFile(filePath)
+		if err != nil {
+			return fmt.Errorf("Process file: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func processFile(path string) error {
+	file, err := os.OpenFile(path, os.O_RDWR, 0644)
+	if err != nil {
+		return fmt.Errorf("Open file: %w", err)
+	}
+	defer file.Close()
+
+	contents, err := io.ReadAll(file)
+	if err != nil {
+		return fmt.Errorf("Read all: %w", err)
+	}
+
+	// If the file doesn't contain any markers, don't do anything
+	if !mtuTableStartRegex.Match(contents) {
+		return nil
+	}
+
+	contentsStr := string(contents)
+	var sb strings.Builder
+
+	for {
+		loc := mtuTableStartRegex.FindStringSubmatchIndex(contentsStr)
+		// No more matches
+		if loc == nil {
+			// Write the remaining content
+			sb.WriteString(contentsStr)
+			break
+		}
+
+		stopIndex := strings.Index(contentsStr, mtuTableMarkerStop)
+		if stopIndex == -1 {
+			// Write the remaining content
+			sb.WriteString(contentsStr)
+			break
+		}
+
+		// Write content including start tag
+		sb.WriteString(contentsStr[:loc[1]])
+
+		printTableMatrix(&sb)
+
+		// Write stop marker
+		sb.WriteString(contentsStr[stopIndex : stopIndex+len(mtuTableMarkerStop)])
+
+		// Shrink off processed portion
+		contentsStr = contentsStr[stopIndex+len(mtuTableMarkerStop):]
+	}
+
+	_, err = file.Seek(0, 0)
+	if err != nil {
+		return fmt.Errorf("seek: %w", err)
+	}
+
+	err = file.Truncate(0)
+	if err != nil {
+		return fmt.Errorf("truncate: %w", err)
+	}
+
+	_, err = io.Copy(file, strings.NewReader(sb.String()))
+	if err != nil {
+		return fmt.Errorf("copy: %w", err)
+	}
+
+	return nil
+}

--- a/tools/mtu-calc/table.go
+++ b/tools/mtu-calc/table.go
@@ -1,0 +1,495 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"slices"
+	"strings"
+)
+
+func printTableMatrix(w io.Writer) {
+	arches := []Arch{
+		x86,
+		arm,
+		arm64,
+		armV7,
+		riscv,
+	}
+
+	for _, frags := range []bool{false, true} {
+		vars := defaultVars()
+
+		maxWidths := make([]int, len(arches))
+		for _, row := range varTable {
+			for _, subrow := range row.Subrow {
+				for i, arch := range arches {
+					vars.Arch = arch
+					vars.Frags = frags
+					var mtu string
+					if subrow.Render == nil {
+						mtu = RenderDefault(subrow, vars)
+					} else {
+						mtu = subrow.Render(subrow, vars)
+					}
+					width := len([]rune(mtu))
+					if width > maxWidths[i] {
+						maxWidths[i] = width
+					}
+				}
+			}
+		}
+
+		if frags {
+			fmt.Fprintln(w, "\n=== \"XDP with Fragments\"")
+		} else {
+			fmt.Fprintln(w, "\n=== \"Plain XDP\"")
+		}
+		fmt.Fprintln(w)
+		fmt.Fprint(w, "    | Vendor           | Driver                |")
+		for i, arch := range arches {
+			fmt.Fprintf(w, " %-*s |", maxWidths[i], arch.String())
+		}
+		fmt.Fprintln(w)
+		fmt.Fprint(w, "    | ---------------- | --------------------- |")
+		for i := range arches {
+			fmt.Fprint(w, " ", strings.Repeat("-", maxWidths[i]), " |")
+		}
+		fmt.Fprintln(w)
+
+		for _, row := range varTable {
+			for _, subrow := range row.Subrow {
+				fmt.Fprintf(w, "    | %-16s | %-21s |",
+					row.Vendor,
+					subrow.Driver,
+				)
+
+				for i, arch := range arches {
+					vars.Arch = arch
+					vars.Frags = frags
+					var mtu string
+					if subrow.Render == nil {
+						mtu = RenderDefault(subrow, vars)
+					} else {
+						mtu = subrow.Render(subrow, vars)
+					}
+					fmt.Fprintf(w, " %-*s |", maxWidths[i], mtu)
+				}
+				fmt.Fprintln(w)
+			}
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+type footnote string
+
+func (f footnote) String() string {
+	return fmt.Sprintf("%s: %s", f.Ref(), string(f))
+}
+
+func (f footnote) Ref() string {
+	return fmt.Sprintf("[^%d]", slices.Index(tableFootnotes, f)+1)
+}
+
+var (
+	infinityFootnote    = footnote("Driver has no MTU limit")
+	nicSpecificFootnote = footnote("MTU limit specified by firmware")
+	tunFootnote         = footnote("Depends on slave device(s)")
+	tableFootnotes      = []footnote{
+		footnote("reserved"),
+		infinityFootnote,
+		nicSpecificFootnote,
+		tunFootnote,
+	}
+)
+
+var varTable = []tableRow{
+	{
+		Vendor: "Kernel",
+		Subrow: []tableSubrow{
+			{
+				Driver:       "Veth",
+				VersionXDP:   KernelVersion{4, 19, 0},
+				VersionFrags: KernelVersion{5, 5, 0},
+				DriverFunc:   calcVethMTU,
+			},
+			{
+				Driver:       "VirtIO",
+				VersionXDP:   KernelVersion{4, 10, 0},
+				VersionFrags: KernelVersion{6, 3, 0},
+				DriverFunc:   calcVirtioNetMTU,
+			},
+			{
+				Driver:     "Tun",
+				VersionXDP: KernelVersion{4, 14, 0},
+				DriverFunc: calcTunMTU,
+			},
+			{
+				Driver:     "Bond",
+				VersionXDP: KernelVersion{5, 15, 0},
+				Render: func(subrow tableSubrow, vars vars) string {
+					if vars.KernelVersion.Less(subrow.VersionXDP) {
+						return ":material-close:"
+					}
+
+					return tunFootnote.Ref()
+				},
+			},
+		},
+	},
+	{
+		Vendor: "Xen",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "Netfront",
+				VersionXDP: KernelVersion{5, 9, 0},
+				DriverFunc: calcXenNetfrontMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Amazon",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "ENA",
+				VersionXDP: KernelVersion{5, 6, 0},
+				DriverFunc: calcEnaMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Aquantia/Marvell",
+		Subrow: []tableSubrow{
+			{
+				Driver:       "AQtion",
+				VersionXDP:   KernelVersion{5, 19, 0},
+				VersionFrags: KernelVersion{5, 19, 0},
+				DriverFunc:   calcAQMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Broadcom",
+		Subrow: []tableSubrow{
+			{
+				Driver:       "BNXT",
+				VersionXDP:   KernelVersion{4, 11, 0},
+				VersionFrags: KernelVersion{5, 19, 0},
+				DriverFunc:   calcBNXTMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Cavium",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "Thunder (nicvf)",
+				VersionXDP: KernelVersion{4, 12, 0},
+				DriverFunc: calcNICVFMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Engelder",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "TSN Endpoint",
+				VersionXDP: KernelVersion{6, 3, 0},
+				DriverFunc: calcTsnepMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Freescale",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "FEC",
+				VersionXDP: KernelVersion{6, 2, 0},
+				DriverFunc: calcFecMTU,
+			},
+			{
+				Driver:     "DPAA",
+				VersionXDP: KernelVersion{5, 11, 0},
+				DriverFunc: calcDPAAMTU,
+			},
+			{
+				Driver:     "DPAA2",
+				VersionXDP: KernelVersion{5, 0, 0},
+				Render: func(subrow tableSubrow, vars vars) string {
+					if vars.KernelVersion.Less(subrow.VersionXDP) {
+						return ":material-close:"
+					}
+
+					return "?" + nicSpecificFootnote.Ref()
+				},
+			},
+			{
+				Driver:     "ENETC",
+				VersionXDP: KernelVersion{5, 13, 0},
+				DriverFunc: calcENETCMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Fungible",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "Funeth",
+				VersionXDP: KernelVersion{5, 18, 0},
+				DriverFunc: calcFunMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Google",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "GVE",
+				VersionXDP: KernelVersion{6, 4, 0},
+				DriverFunc: calcGVEMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Intel",
+		Subrow: []tableSubrow{
+			{
+				Driver:       "I40e",
+				VersionXDP:   KernelVersion{4, 13, 0},
+				VersionFrags: KernelVersion{6, 4, 0},
+				DriverFunc:   calcI40EMTU,
+			},
+			{
+				Driver:       "ICE",
+				VersionXDP:   KernelVersion{5, 5, 0},
+				VersionFrags: KernelVersion{6, 3, 0},
+				DriverFunc:   calcICEMTU,
+			},
+			{
+				Driver:     "IGB",
+				VersionXDP: KernelVersion{5, 10, 0},
+				DriverFunc: calcIGBMTU,
+			},
+			{
+				Driver:     "IGC",
+				VersionXDP: KernelVersion{5, 13, 0},
+				DriverFunc: calcIGCMTU,
+			},
+			{
+				Driver:     "IXGBE",
+				VersionXDP: KernelVersion{4, 12, 0},
+				DriverFunc: calcIXGBE,
+			},
+			{
+				Driver:     "IXGBEVF",
+				VersionXDP: KernelVersion{4, 17, 0},
+				DriverFunc: calcIXGBEVF,
+			},
+		},
+	},
+	{
+		Vendor: "Marvell",
+		Subrow: []tableSubrow{
+			{
+				Driver:       "NETA",
+				VersionXDP:   KernelVersion{5, 5, 0},
+				VersionFrags: KernelVersion{5, 18, 0},
+				DriverFunc:   calcMVNetaMTU,
+			},
+			{
+				Driver:       "PPv2",
+				VersionXDP:   KernelVersion{5, 9, 0},
+				VersionFrags: KernelVersion{5, 18, 0},
+				DriverFunc:   calcMVPP2MTU,
+			},
+			{
+				Driver:     "Octeon TX2",
+				VersionXDP: KernelVersion{5, 16, 0},
+				DriverFunc: calcOTX2MTU,
+			},
+		},
+	},
+	{
+		Vendor: "MediaTek",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "MTK",
+				VersionXDP: KernelVersion{6, 0, 0},
+				DriverFunc: calcMtkMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Mellanox",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "MLX4",
+				VersionXDP: KernelVersion{4, 8, 0},
+				DriverFunc: calcMLX4MTU,
+			},
+			{
+				Driver:       "MLX5",
+				VersionXDP:   KernelVersion{4, 9, 0},
+				VersionFrags: KernelVersion{5, 18, 0},
+				DriverFunc:   calcMLX5MTU,
+			},
+		},
+	},
+	{
+		Vendor: "Microchip",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "LAN966x",
+				VersionXDP: KernelVersion{6, 2, 0},
+				DriverFunc: calcLan966xMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Microsoft",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "Mana",
+				VersionXDP: KernelVersion{5, 17, 0},
+				DriverFunc: calcManaMTU,
+			},
+			{
+				Driver:     "Hyper-V",
+				VersionXDP: KernelVersion{5, 6, 0},
+				DriverFunc: calcNetvscMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Netronome",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "NFP",
+				VersionXDP: KernelVersion{4, 10, 0},
+				DriverFunc: calcNFPMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Pensando",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "Ionic",
+				VersionXDP: KernelVersion{6, 9, 0},
+				DriverFunc: calcIonicMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Qlogic",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "QEDE",
+				VersionXDP: KernelVersion{4, 10, 0},
+				DriverFunc: calcQedeMTU,
+			},
+		},
+	},
+	{
+		Vendor: "Solarflare",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "SFP (SFC9xxx PF/VF)",
+				VersionXDP: KernelVersion{4, 10, 0},
+				DriverFunc: calcSFPMTUModel(hunt),
+			},
+			{
+				Driver:     "SFP (Riverhead)",
+				VersionXDP: KernelVersion{4, 10, 0},
+				DriverFunc: calcSFPMTUModel(ef100),
+			},
+			{
+				Driver:     "SFP (SFC4000A)",
+				VersionXDP: KernelVersion{4, 10, 0},
+				DriverFunc: calcSFPMTUModel(falcon_a1),
+			},
+			{
+				Driver:     "SFP (SFC4000B)",
+				VersionXDP: KernelVersion{4, 10, 0},
+				DriverFunc: calcSFPMTUModel(falcon_b0),
+			},
+			{
+				Driver:     "SFP (SFC9020/SFL9021)",
+				VersionXDP: KernelVersion{4, 10, 0},
+				DriverFunc: calcSFPMTUModel(siena_a0),
+			},
+		},
+	},
+	{
+		Vendor: "Socionext",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "NetSec",
+				VersionXDP: KernelVersion{5, 3, 0},
+				DriverFunc: calcNetsecMTU,
+			},
+		},
+	},
+	{
+		Vendor: "STMicro",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "ST MAC",
+				VersionXDP: KernelVersion{5, 13, 0},
+				DriverFunc: calcStmmacMTU,
+			},
+		},
+	},
+	{
+		Vendor: "TI",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "CPSW",
+				VersionXDP: KernelVersion{5, 3, 0},
+				DriverFunc: calcCPSWMTU,
+			},
+		},
+	},
+	{
+		Vendor: "VMWare",
+		Subrow: []tableSubrow{
+			{
+				Driver:     "VMXNET 3",
+				VersionXDP: KernelVersion{6, 6, 0},
+				DriverFunc: calcVmxnet3MTU,
+			},
+		},
+	},
+}
+
+type tableRow struct {
+	Vendor string
+	Subrow []tableSubrow
+}
+
+type tableSubrow struct {
+	Driver       string
+	VersionXDP   KernelVersion
+	VersionFrags KernelVersion
+	DriverFunc   func(vars vars) int
+	Render       func(subrow tableSubrow, vars vars) string
+}
+
+func RenderDefault(subrow tableSubrow, vars vars) string {
+	if vars.KernelVersion.Less(subrow.VersionXDP) {
+		return ":material-close:"
+	}
+
+	mtu := subrow.DriverFunc(vars)
+
+	if vars.Frags && subrow.VersionFrags == KernelVersionUnknown {
+		return ":material-close:"
+	}
+
+	if mtu == math.MaxInt {
+		return "∞" + infinityFootnote.Ref()
+	}
+
+	return fmt.Sprint(mtu)
+}

--- a/tools/mtu-calc/vars.go
+++ b/tools/mtu-calc/vars.go
@@ -1,0 +1,311 @@
+package main
+
+type Arch int
+
+const (
+	alpha Arch = iota
+	alphaGeneric
+	alphaEV6
+	arc
+	arm
+	armV6
+	armV7
+	arm64
+	csky610
+	csky807
+	csky810
+	csky860
+	hexagon
+	loongarch
+	m68k
+	microblaze
+	mips
+	nios2
+	openrisc
+	parisc
+	powerpc
+	riscv
+	s390
+	sh
+	sparc32
+	sparc64
+	um
+	x86
+	xtensa
+)
+
+func (a Arch) String() string {
+	switch a {
+	case alpha:
+		return "alpha"
+	case alphaGeneric:
+		return "alpha-generic"
+	case alphaEV6:
+		return "alpha-ev6"
+	case arc:
+		return "arc"
+	case arm:
+		return "arm"
+	case armV6:
+		return "armv6"
+	case armV7:
+		return "armv7"
+	case arm64:
+		return "arm64"
+	case csky610:
+		return "csky610"
+	case csky807:
+		return "csky807"
+	case csky810:
+		return "csky810"
+	case csky860:
+		return "csky860"
+	case hexagon:
+		return "hexagon"
+	case loongarch:
+		return "loongarch"
+	case m68k:
+		return "m68k"
+	case microblaze:
+		return "microblaze"
+	case mips:
+		return "mips"
+	case nios2:
+		return "nios2"
+	case openrisc:
+		return "openrisc"
+	case parisc:
+		return "parisc"
+	case powerpc:
+		return "powerpc"
+	case riscv:
+		return "riscv"
+	case s390:
+		return "s390"
+	case sh:
+		return "sh"
+	case sparc32:
+		return "sparc32"
+	case sparc64:
+		return "sparc64"
+	case um:
+		return "um"
+	case x86:
+		return "x86"
+	case xtensa:
+		return "xtensa"
+	}
+	return "unknown"
+
+}
+
+type KernelVersion struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+func (v KernelVersion) Less(o KernelVersion) bool {
+	if v.Major != o.Major {
+		return v.Major < o.Major
+	}
+	if v.Minor != o.Minor {
+		return v.Minor < o.Minor
+	}
+	return v.Patch < o.Patch
+}
+
+func (v KernelVersion) Greater(o KernelVersion) bool {
+	if v.Major != o.Major {
+		return v.Major > o.Major
+	}
+	if v.Minor != o.Minor {
+		return v.Minor > o.Minor
+	}
+	return v.Patch > o.Patch
+}
+
+var (
+	KernelVersionUnknown = KernelVersion{0, 0, 0}
+	KernelVersion4_19    = KernelVersion{4, 19, 0}
+	KernelVersion5_4     = KernelVersion{5, 4, 0}
+	KernelVersion5_10    = KernelVersion{5, 10, 0}
+	KernelVersion5_15    = KernelVersion{5, 15, 0}
+	KernelVersion6_1     = KernelVersion{6, 1, 0}
+	KernelVersion6_6     = KernelVersion{6, 6, 0}
+	KernelVersion6_9     = KernelVersion{6, 9, 0}
+)
+
+type SFCModel int
+
+const (
+	hunt SFCModel = iota
+	ef100
+	falcon_a1
+	falcon_b0
+	siena_a0
+)
+
+type vars struct {
+	Frags             bool
+	Arch              Arch
+	PageSize          int
+	XDPPacketheadroom int
+	KernelVersion     KernelVersion
+	ConfigSKBFrags    *int
+
+	// veth specific
+	PeerHardHeaderLen int
+
+	// DPAA specific
+	ERRATUM_A050385 bool
+
+	// I40e specific
+	I40ELegacyRXENA bool
+
+	// ICE specific
+	ICELegacyRX bool
+
+	// IGB specific
+	IGBUseLargeRing bool
+	IGBUseSKB       bool
+
+	// IXGBE specific
+	IXGBRX3kBuffer bool
+	IXGBUseSKB     bool
+
+	// IXGBEVF specific
+	IXGBEVLargeBuffer bool
+	IXGBEVFUseSKB     bool
+
+	// SFP specific
+	SFCModel SFCModel
+}
+
+func (v vars) NetIPAlign() int {
+	switch v.Arch {
+	case x86, arm64, powerpc:
+		return 0
+	}
+	return 2
+}
+
+func (v vars) SMPCacheBytes() int {
+	switch v.Arch {
+	case alpha:
+		return 32
+	case alphaGeneric, alphaEV6:
+		return 64
+	case arc:
+		return 128
+	case microblaze:
+		return 1 << 5
+	case parisc:
+		return 16
+	case sparc32:
+		return 1 << 5
+	case sparc64:
+		return 1 << 6
+	case xtensa:
+		return 32
+	default:
+		return v.L1CacheBytes()
+	}
+}
+
+func (v vars) L1CacheBytes() int {
+	switch v.Arch {
+	case arc:
+		return 1 << 6
+	case arm:
+		return 1 << 5
+	case armV6:
+		return 1 << 6
+	case armV7:
+		return 1 << 7
+	case arm64:
+		return 1 << 6
+	case csky610:
+		return 1 << 4
+	case csky807, csky810:
+		return 1 << 5
+	case csky860:
+		return 1 << 6
+	case hexagon:
+		return 1 << 5
+	case loongarch:
+		return 1 << 6
+	case microblaze:
+		return 1 << 5
+	case mips:
+		return 1 << 5
+	case nios2:
+		return 1 << 5
+	case openrisc:
+		return 16
+	case parisc:
+		return 16
+	case riscv:
+		return 1 << 6
+	case s390:
+		return 256
+	case sh:
+		return 1 << 5
+	case sparc32:
+		return 32
+	case um:
+		return 1 << 5
+	case x86:
+		return 1 << 6
+	case xtensa:
+		return 1 << 5
+	}
+
+	panic("missing L1 cache size for arch")
+}
+
+func (v vars) SizeOfSKBSharedInfo() int {
+	// NOTE: manual checking of multiple distros and kernel versions all resulted in 320
+	// This is likely not universal, but very complex to determine and model at this time.
+	return 320
+}
+
+func (v vars) MaxSKBFrags() int {
+	switch v.KernelVersion {
+	case KernelVersion6_6, KernelVersion6_9:
+		if v.ConfigSKBFrags != nil {
+			return *v.ConfigSKBFrags
+		}
+		return 17
+
+	default:
+		if (65536/v.PageSize + 1) < 16 {
+			return 16
+		}
+		return 65536/v.PageSize + 1
+	}
+}
+
+func (v vars) NetSKBPad() int {
+	return max(32, v.L1CacheBytes())
+}
+
+func defaultVars() vars {
+	return vars{
+		Frags:             false,
+		Arch:              x86,
+		PageSize:          4096,
+		XDPPacketheadroom: 256,
+		KernelVersion:     KernelVersion6_9,
+
+		PeerHardHeaderLen: 0,
+
+		IGBUseLargeRing: true,
+
+		IXGBRX3kBuffer: true,
+
+		IXGBEVLargeBuffer: true,
+
+		SFCModel: hunt,
+	}
+}


### PR DESCRIPTION
It turns out that every NIC driver enforces a different maximum MTU. This commit adds a table that allows users to see the maximum MTU for each driver on different platforms, with and without fragments enabled.

Fixes: #17