### PR TITLE
Correction for bpf_for example

### DIFF
--- a/docs/linux/concepts/loops.md
+++ b/docs/linux/concepts/loops.md
@@ -95,10 +95,10 @@ non-inclusive.
 
 Libbpf also provides macros to provide a more natural feeling way to write the above:
 ```c
-int *v;
+int v;
 
 bpf_for(v, start, end) {
-    bpf_printk("X = %d", *v);
+    bpf_printk("X = %d", v);
 }
 ```
 


### PR DESCRIPTION
The `bpf_for` macro needs an integer as the loop counter, not an integer pointer. Otherwise, we get a cast error from int to int*.