### PR TITLE
kfuncs: Add bpf_arena_alloc_pages and bpf_arena_free_pages kfuncs

### DIFF
--- a/data/feature-versions.yaml
+++ b/data/feature-versions.yaml
@@ -2024,3 +2024,9 @@
     - name: bpf_session_cookie
       version: v6.10
       commit: 5c919acef85147886eb2abf86fb147f94680a8b0
+    - name: bpf_arena_alloc_pages
+      version: v6.9
+      commit: 317460317a02a1af512697e6e964298dedd8a163
+    - name: bpf_arena_free_pages
+      version: v6.9
+      commit: 317460317a02a1af512697e6e964298dedd8a163

--- a/data/kfuncs.yaml
+++ b/data/kfuncs.yaml
@@ -401,3 +401,12 @@ sets:
       - BPF_PROG_TYPE_KPROBE
     attach_type:
       - BPF_TRACE_KPROBE_SESSION
+
+  arena_kfuncs:
+    funcs:
+      - name: bpf_arena_alloc_pages
+        flags: [KF_TRUSTED_ARGS, KF_SLEEPABLE]
+      - name: bpf_arena_free_pages
+        flags: [KF_TRUSTED_ARGS, KF_SLEEPABLE]
+    program_types:
+      - BPF_PROG_TYPE_UNSPEC

--- a/docs/linux/kfuncs/SUMMARY.md
+++ b/docs/linux/kfuncs/SUMMARY.md
@@ -48,6 +48,9 @@
   - [bpf_list_push_back_impl](bpf_list_push_back_impl.md)
   - [bpf_list_pop_front](bpf_list_pop_front.md)
   - [bpf_list_pop_back](bpf_list_pop_back.md)
+- BPF Arena KFuncs
+  - [bpf_arena_alloc_pages](bpf_arena_alloc_pages.md)
+  - [bpf_arena_free_pages](bpf_arena_free_pages.md)
 - BPF task KFuncs
   - [bpf_task_acquire](bpf_task_acquire.md)
   - [bpf_task_release](bpf_task_release.md)

--- a/docs/linux/kfuncs/bpf_arena_alloc_pages.md
+++ b/docs/linux/kfuncs/bpf_arena_alloc_pages.md
@@ -1,0 +1,67 @@
+---
+title: "KFunc 'bpf_arena_alloc_pages'"
+description: "This page documents the 'bpf_arena_alloc_pages' eBPF kfunc, including its definition, usage, program types that can use it, and examples."
+---
+# KFunc `bpf_arena_alloc_pages`
+
+<!-- [FEATURE_TAG](bpf_arena_alloc_pages) -->
+[:octicons-tag-24: v6.9](https://github.com/torvalds/linux/commit/317460317a02a1af512697e6e964298dedd8a163)
+<!-- [/FEATURE_TAG] -->
+
+Allocate pages of memory for a arena.
+
+## Definition
+
+`p__map`: Pointer to the `BPF_MAP_TYPE_ARENA` map.
+
+`addr__ign`: Address of the start of the page(s) to be allocated, must be a page aligned address.
+
+`page_cnt`: Number of pages to allocate.
+
+`node_id`: NUMA node to allocate memory from.
+
+`flags`: Flags for future use, currently no valid flags exist.
+
+<!-- [KFUNC_DEF] -->
+`#!c void *bpf_arena_alloc_pages(void *p__map, void *addr__ign, u32 page_cnt, int node_id, u64 flags)`
+
+!!! note
+    This function may sleep, and therefore can only be used from [sleepable programs](../syscall/BPF_PROG_LOAD.md/#bpf_f_sleepable).
+<!-- [/KFUNC_DEF] -->
+
+## Usage
+
+A BPF arena is a region of memory that can be shared between BPF programs and userspace programs. This allows for the creation of custom data structures that can be shared between BPF programs and userspace programs.
+
+An arena is created as a map, upon its creation a maximum memory size is specified, but this memory isn't allocated at creation, rather, an arena allows on demand allocation of memory pages.
+
+The kfunc is used to allocate these pages.
+
+### Program types
+
+The following program types can make use of this kfunc:
+
+<!-- [KFUNC_PROG_REF] -->
+- [BPF_PROG_TYPE_CGROUP_SKB](../program-type/BPF_PROG_TYPE_CGROUP_SKB.md)
+- [BPF_PROG_TYPE_CGROUP_SOCK_ADDR](../program-type/BPF_PROG_TYPE_CGROUP_SOCK_ADDR.md)
+- [BPF_PROG_TYPE_LSM](../program-type/BPF_PROG_TYPE_LSM.md)
+- [BPF_PROG_TYPE_LWT_IN](../program-type/BPF_PROG_TYPE_LWT_IN.md)
+- [BPF_PROG_TYPE_LWT_OUT](../program-type/BPF_PROG_TYPE_LWT_OUT.md)
+- [BPF_PROG_TYPE_LWT_SEG6LOCAL](../program-type/BPF_PROG_TYPE_LWT_SEG6LOCAL.md)
+- [BPF_PROG_TYPE_LWT_XMIT](../program-type/BPF_PROG_TYPE_LWT_XMIT.md)
+- [BPF_PROG_TYPE_NETFILTER](../program-type/BPF_PROG_TYPE_NETFILTER.md)
+- [BPF_PROG_TYPE_SCHED_ACT](../program-type/BPF_PROG_TYPE_SCHED_ACT.md)
+- [BPF_PROG_TYPE_SCHED_CLS](../program-type/BPF_PROG_TYPE_SCHED_CLS.md)
+- [BPF_PROG_TYPE_SK_SKB](../program-type/BPF_PROG_TYPE_SK_SKB.md)
+- [BPF_PROG_TYPE_SOCKET_FILTER](../program-type/BPF_PROG_TYPE_SOCKET_FILTER.md)
+- [BPF_PROG_TYPE_STRUCT_OPS](../program-type/BPF_PROG_TYPE_STRUCT_OPS.md)
+- [BPF_PROG_TYPE_SYSCALL](../program-type/BPF_PROG_TYPE_SYSCALL.md)
+- [BPF_PROG_TYPE_TRACING](../program-type/BPF_PROG_TYPE_TRACING.md)
+- [BPF_PROG_TYPE_XDP](../program-type/BPF_PROG_TYPE_XDP.md)
+<!-- [/KFUNC_PROG_REF] -->
+
+### Example
+
+!!! example "Docs could be improved"
+    This part of the docs is incomplete, contributions are very welcome
+

--- a/docs/linux/kfuncs/bpf_arena_free_pages.md
+++ b/docs/linux/kfuncs/bpf_arena_free_pages.md
@@ -1,0 +1,63 @@
+---
+title: "KFunc 'bpf_arena_free_pages'"
+description: "This page documents the 'bpf_arena_free_pages' eBPF kfunc, including its definition, usage, program types that can use it, and examples."
+---
+# KFunc `bpf_arena_free_pages`
+
+<!-- [FEATURE_TAG](bpf_arena_free_pages) -->
+[:octicons-tag-24: v6.9](https://github.com/torvalds/linux/commit/317460317a02a1af512697e6e964298dedd8a163)
+<!-- [/FEATURE_TAG] -->
+
+Free pages of memory for a arena.
+
+## Definition
+
+`p__map`: Pointer to the `BPF_MAP_TYPE_ARENA` map.
+
+`ptr__ign`:Address of the start of the page(s) to be freed, must be a page aligned address.
+
+`page_cnt`: Number of pages to free.
+
+<!-- [KFUNC_DEF] -->
+`#!c void bpf_arena_free_pages(void *p__map, void *ptr__ign, u32 page_cnt)`
+
+!!! note
+    This function may sleep, and therefore can only be used from [sleepable programs](../syscall/BPF_PROG_LOAD.md/#bpf_f_sleepable).
+<!-- [/KFUNC_DEF] -->
+
+## Usage
+
+A BPF arena is a region of memory that can be shared between BPF programs and userspace programs. This allows for the creation of custom data structures that can be shared between BPF programs and userspace programs.
+
+An arena is created as a map, upon its creation a maximum memory size is specified, but this memory isn't allocated at creation, rather, an arena allows on demand allocation of memory pages.
+
+The kfunc is used to free these pages.
+
+### Program types
+
+The following program types can make use of this kfunc:
+
+<!-- [KFUNC_PROG_REF] -->
+- [BPF_PROG_TYPE_CGROUP_SKB](../program-type/BPF_PROG_TYPE_CGROUP_SKB.md)
+- [BPF_PROG_TYPE_CGROUP_SOCK_ADDR](../program-type/BPF_PROG_TYPE_CGROUP_SOCK_ADDR.md)
+- [BPF_PROG_TYPE_LSM](../program-type/BPF_PROG_TYPE_LSM.md)
+- [BPF_PROG_TYPE_LWT_IN](../program-type/BPF_PROG_TYPE_LWT_IN.md)
+- [BPF_PROG_TYPE_LWT_OUT](../program-type/BPF_PROG_TYPE_LWT_OUT.md)
+- [BPF_PROG_TYPE_LWT_SEG6LOCAL](../program-type/BPF_PROG_TYPE_LWT_SEG6LOCAL.md)
+- [BPF_PROG_TYPE_LWT_XMIT](../program-type/BPF_PROG_TYPE_LWT_XMIT.md)
+- [BPF_PROG_TYPE_NETFILTER](../program-type/BPF_PROG_TYPE_NETFILTER.md)
+- [BPF_PROG_TYPE_SCHED_ACT](../program-type/BPF_PROG_TYPE_SCHED_ACT.md)
+- [BPF_PROG_TYPE_SCHED_CLS](../program-type/BPF_PROG_TYPE_SCHED_CLS.md)
+- [BPF_PROG_TYPE_SK_SKB](../program-type/BPF_PROG_TYPE_SK_SKB.md)
+- [BPF_PROG_TYPE_SOCKET_FILTER](../program-type/BPF_PROG_TYPE_SOCKET_FILTER.md)
+- [BPF_PROG_TYPE_STRUCT_OPS](../program-type/BPF_PROG_TYPE_STRUCT_OPS.md)
+- [BPF_PROG_TYPE_SYSCALL](../program-type/BPF_PROG_TYPE_SYSCALL.md)
+- [BPF_PROG_TYPE_TRACING](../program-type/BPF_PROG_TYPE_TRACING.md)
+- [BPF_PROG_TYPE_XDP](../program-type/BPF_PROG_TYPE_XDP.md)
+<!-- [/KFUNC_PROG_REF] -->
+
+### Example
+
+!!! example "Docs could be improved"
+    This part of the docs is incomplete, contributions are very welcome
+

--- a/docs/linux/kfuncs/index.md
+++ b/docs/linux/kfuncs/index.md
@@ -73,6 +73,13 @@ A set of KFuncs to allocate and deallocate custom objects for the purposes of bu
 - [bpf_list_pop_front](bpf_list_pop_front.md)
 - [bpf_list_pop_back](bpf_list_pop_back.md)
 
+## BPF Arena KFuncs
+
+KFuncs used to allocate and free pages from an arena.
+
+- [bpf_arena_alloc_pages](bpf_arena_alloc_pages.md)
+- [bpf_arena_free_pages](bpf_arena_free_pages.md)
+
 ## BPF task KFuncs
 
 Kfuncs used to aquire and release task reference.

--- a/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SKB.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SKB.md
@@ -318,6 +318,8 @@ char _license[] SEC("license") = "GPL";
 
 <!-- [PROG_KFUNC_REF] -->
 ??? abstract "Supported kfuncs"
+    - [bpf_arena_alloc_pages](../kfuncs/bpf_arena_alloc_pages.md)
+    - [bpf_arena_free_pages](../kfuncs/bpf_arena_free_pages.md)
     - [bpf_cast_to_kern_ctx](../kfuncs/bpf_cast_to_kern_ctx.md)
     - [bpf_dynptr_adjust](../kfuncs/bpf_dynptr_adjust.md)
     - [bpf_dynptr_clone](../kfuncs/bpf_dynptr_clone.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SOCK_ADDR.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SOCK_ADDR.md
@@ -402,6 +402,8 @@ cGroup socket buffer programs are attached to cgroups via the [`BPF_PROG_ATTACH`
 
 <!-- [PROG_KFUNC_REF] -->
 ??? abstract "Supported kfuncs"
+    - [bpf_arena_alloc_pages](../kfuncs/bpf_arena_alloc_pages.md)
+    - [bpf_arena_free_pages](../kfuncs/bpf_arena_free_pages.md)
     - [bpf_cast_to_kern_ctx](../kfuncs/bpf_cast_to_kern_ctx.md)
     - [bpf_dynptr_adjust](../kfuncs/bpf_dynptr_adjust.md)
     - [bpf_dynptr_clone](../kfuncs/bpf_dynptr_clone.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_LSM.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_LSM.md
@@ -173,6 +173,8 @@ Not all helper functions are available in all program types. These are the helpe
 
 <!-- [PROG_KFUNC_REF] -->
 ??? abstract "Supported kfuncs"
+    - [bpf_arena_alloc_pages](../kfuncs/bpf_arena_alloc_pages.md)
+    - [bpf_arena_free_pages](../kfuncs/bpf_arena_free_pages.md)
     - [bpf_cast_to_kern_ctx](../kfuncs/bpf_cast_to_kern_ctx.md)
     - [bpf_cgroup_acquire](../kfuncs/bpf_cgroup_acquire.md)
     - [bpf_cgroup_ancestor](../kfuncs/bpf_cgroup_ancestor.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_LWT_IN.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_LWT_IN.md
@@ -210,6 +210,8 @@ Not all helper functions are available in all program types. These are the helpe
 
 <!-- [PROG_KFUNC_REF] -->
 ??? abstract "Supported kfuncs"
+    - [bpf_arena_alloc_pages](../kfuncs/bpf_arena_alloc_pages.md)
+    - [bpf_arena_free_pages](../kfuncs/bpf_arena_free_pages.md)
     - [bpf_cast_to_kern_ctx](../kfuncs/bpf_cast_to_kern_ctx.md)
     - [bpf_dynptr_adjust](../kfuncs/bpf_dynptr_adjust.md)
     - [bpf_dynptr_clone](../kfuncs/bpf_dynptr_clone.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_LWT_OUT.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_LWT_OUT.md
@@ -207,6 +207,8 @@ Not all helper functions are available in all program types. These are the helpe
 
 <!-- [PROG_KFUNC_REF] -->
 ??? abstract "Supported kfuncs"
+    - [bpf_arena_alloc_pages](../kfuncs/bpf_arena_alloc_pages.md)
+    - [bpf_arena_free_pages](../kfuncs/bpf_arena_free_pages.md)
     - [bpf_cast_to_kern_ctx](../kfuncs/bpf_cast_to_kern_ctx.md)
     - [bpf_dynptr_adjust](../kfuncs/bpf_dynptr_adjust.md)
     - [bpf_dynptr_clone](../kfuncs/bpf_dynptr_clone.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_LWT_XMIT.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_LWT_XMIT.md
@@ -160,6 +160,8 @@ Not all helper functions are available in all program types. These are the helpe
 
 <!-- [PROG_KFUNC_REF] -->
 ??? abstract "Supported kfuncs"
+    - [bpf_arena_alloc_pages](../kfuncs/bpf_arena_alloc_pages.md)
+    - [bpf_arena_free_pages](../kfuncs/bpf_arena_free_pages.md)
     - [bpf_cast_to_kern_ctx](../kfuncs/bpf_cast_to_kern_ctx.md)
     - [bpf_dynptr_adjust](../kfuncs/bpf_dynptr_adjust.md)
     - [bpf_dynptr_clone](../kfuncs/bpf_dynptr_clone.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_SCHED_CLS.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_SCHED_CLS.md
@@ -209,6 +209,8 @@ Not all helper functions are available in all program types. These are the helpe
 
 <!-- [PROG_KFUNC_REF] -->
 ??? abstract "Supported kfuncs"
+    - [bpf_arena_alloc_pages](../kfuncs/bpf_arena_alloc_pages.md)
+    - [bpf_arena_free_pages](../kfuncs/bpf_arena_free_pages.md)
     - [bpf_cast_to_kern_ctx](../kfuncs/bpf_cast_to_kern_ctx.md)
     - [bpf_cgroup_acquire](../kfuncs/bpf_cgroup_acquire.md)
     - [bpf_cgroup_ancestor](../kfuncs/bpf_cgroup_ancestor.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_SK_SKB.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_SK_SKB.md
@@ -247,6 +247,8 @@ out:
 
 <!-- [PROG_KFUNC_REF] -->
 ??? abstract "Supported kfuncs"
+    - [bpf_arena_alloc_pages](../kfuncs/bpf_arena_alloc_pages.md)
+    - [bpf_arena_free_pages](../kfuncs/bpf_arena_free_pages.md)
     - [bpf_cast_to_kern_ctx](../kfuncs/bpf_cast_to_kern_ctx.md)
     - [bpf_dynptr_adjust](../kfuncs/bpf_dynptr_adjust.md)
     - [bpf_dynptr_clone](../kfuncs/bpf_dynptr_clone.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_SOCKET_FILTER.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_SOCKET_FILTER.md
@@ -126,6 +126,8 @@ Not all helper functions are available in all program types. These are the helpe
 
 <!-- [PROG_KFUNC_REF] -->
 ??? abstract "Supported kfuncs"
+    - [bpf_arena_alloc_pages](../kfuncs/bpf_arena_alloc_pages.md)
+    - [bpf_arena_free_pages](../kfuncs/bpf_arena_free_pages.md)
     - [bpf_cast_to_kern_ctx](../kfuncs/bpf_cast_to_kern_ctx.md)
     - [bpf_dynptr_adjust](../kfuncs/bpf_dynptr_adjust.md)
     - [bpf_dynptr_clone](../kfuncs/bpf_dynptr_clone.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_STRUCT_OPS.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_STRUCT_OPS.md
@@ -343,6 +343,8 @@ Not all helper functions are available in all program types. These are the helpe
     - [bbr_sndbuf_expand](../kfuncs/bbr_sndbuf_expand.md)
     - [bbr_ssthresh](../kfuncs/bbr_ssthresh.md)
     - [bbr_undo_cwnd](../kfuncs/bbr_undo_cwnd.md)
+    - [bpf_arena_alloc_pages](../kfuncs/bpf_arena_alloc_pages.md)
+    - [bpf_arena_free_pages](../kfuncs/bpf_arena_free_pages.md)
     - [bpf_cast_to_kern_ctx](../kfuncs/bpf_cast_to_kern_ctx.md)
     - [bpf_cgroup_acquire](../kfuncs/bpf_cgroup_acquire.md)
     - [bpf_cgroup_ancestor](../kfuncs/bpf_cgroup_ancestor.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_SYSCALL.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_SYSCALL.md
@@ -176,6 +176,8 @@ Not all helper functions are available in all program types. These are the helpe
 
 <!-- [PROG_KFUNC_REF] -->
 ??? abstract "Supported kfuncs"
+    - [bpf_arena_alloc_pages](../kfuncs/bpf_arena_alloc_pages.md)
+    - [bpf_arena_free_pages](../kfuncs/bpf_arena_free_pages.md)
     - [bpf_cast_to_kern_ctx](../kfuncs/bpf_cast_to_kern_ctx.md)
     - [bpf_crypto_ctx_acquire](../kfuncs/bpf_crypto_ctx_acquire.md)
     - [bpf_crypto_ctx_create](../kfuncs/bpf_crypto_ctx_create.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_TRACING.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_TRACING.md
@@ -456,6 +456,8 @@ Not all helper functions are available in all program types. These are the helpe
 
 <!-- [PROG_KFUNC_REF] -->
 ??? abstract "Supported kfuncs"
+    - [bpf_arena_alloc_pages](../kfuncs/bpf_arena_alloc_pages.md)
+    - [bpf_arena_free_pages](../kfuncs/bpf_arena_free_pages.md)
     - [bpf_cast_to_kern_ctx](../kfuncs/bpf_cast_to_kern_ctx.md)
     - [bpf_cgroup_acquire](../kfuncs/bpf_cgroup_acquire.md)
     - [bpf_cgroup_ancestor](../kfuncs/bpf_cgroup_ancestor.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_XDP.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_XDP.md
@@ -400,6 +400,8 @@ Not all helper functions are available in all program types. These are the helpe
 
 <!-- [PROG_KFUNC_REF] -->
 ??? abstract "Supported kfuncs"
+    - [bpf_arena_alloc_pages](../kfuncs/bpf_arena_alloc_pages.md)
+    - [bpf_arena_free_pages](../kfuncs/bpf_arena_free_pages.md)
     - [bpf_cast_to_kern_ctx](../kfuncs/bpf_cast_to_kern_ctx.md)
     - [bpf_cgroup_acquire](../kfuncs/bpf_cgroup_acquire.md)
     - [bpf_cgroup_ancestor](../kfuncs/bpf_cgroup_ancestor.md)

--- a/tools/version-finder/patterns.yaml
+++ b/tools/version-finder/patterns.yaml
@@ -721,3 +721,5 @@ patterns:
     - name: bpf_crypto_encrypt
     - name: bpf_session_is_return
     - name: bpf_session_cookie
+    - name: bpf_arena_alloc_pages
+    - name: bpf_arena_free_pages


### PR DESCRIPTION
This commit adds two new kfuncs, bpf_arena_alloc_pages and bpf_arena_free_pages. These kfuncs are used to allocate and free pages from BPF arenas.