### PR TITLE
helper-function: Usage and examples for ring buffers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+venv/** 

--- a/docs/linux/helper-function/bpf_ringbuf_discard.md
+++ b/docs/linux/helper-function/bpf_ringbuf_discard.md
@@ -27,8 +27,7 @@ Nothing. Always succeeds.
 
 ## Usage
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+This function discards the reserved memory in the ring buffer. The `data` argument must be a pointer to the reserved memory. The `flags` argument, similar to [bpf_ringbuf_submit](./bpf_ringbuf_submit.md), can be set to **BPF_RB_NO_WAKEUP**, **BPF_RB_FORCE_WAKEUP**, or **0** to specify how the notification of the discarded data should be handled. This function must be used if space is reserved in the ring buffer but the flow does not lead to [bpf_ringbuf_submit](./bpf_ringbuf_submit.md).
 
 ### Program types
 
@@ -69,5 +68,21 @@ This helper call can be used in the following program types:
 
 ### Example
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+```c
+// Reserve space in the ring buffer
+struct ringbuf_data *rb_data = bpf_ringbuf_reserve(&my_ringbuf, sizeof(struct ringbuf_data), 0);
+if(!rb_data) {
+    // if bpf_ringbuf_reserve fails, print an error message and return
+    bpf_printk("bpf_ringbuf_reserve failed\n");
+    return 1;
+}
+
+if(unhappy_flow) {
+    // Discard the reserved data
+    bpf_ringbuf_discard(rb_data, 0);
+    return 1;
+}
+
+// Submit the reserved data
+bpf_ringbuf_submit(rb_data, 0);
+```

--- a/docs/linux/helper-function/bpf_ringbuf_output.md
+++ b/docs/linux/helper-function/bpf_ringbuf_output.md
@@ -27,8 +27,9 @@ An adaptive notification is a notification sent whenever the user-space process 
 
 ## Usage
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+The `ringbuf` must be a pointer to the ring buffer map. `data` is a pointer to the data that needs to be copied into the ring buffer. The `size` argument specifies the number of bytes to be copied. The `flags` argument defines how the notification of the new data availability should be handled.
+
+This function incurs an extra memory copy operation in comparison to using [bpf_ringbuf_reserve](./bpf_ringbuf_reserve.md)/[bpf_ringbuf_submit](./bpf_ringbuf_submit.md)/[bpf_ringbuf_discard](./bpf_ringbuf_discard.md), but allows submitting records of lengths unknown to the [verifier](https://www.kernel.org/doc/html/next/bpf/ringbuf.html). 
 
 ### Program types
 
@@ -69,5 +70,7 @@ This helper call can be used in the following program types:
 
 ### Example
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+```c
+// Copy data into the ring buffer
+bpf_ringbuf_output(&my_ringbuf, &my_data, sizeof(my_data), 0);
+```

--- a/docs/linux/helper-function/bpf_ringbuf_query.md
+++ b/docs/linux/helper-function/bpf_ringbuf_query.md
@@ -33,8 +33,7 @@ Requested value, or 0, if _flags_ are not recognized.
 
 ## Usage
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+The `ringbuf` must be a pointer to the ring buffer map. The `flags` argument defines what is being queried. This function can be used to query the amount of data not yet consumed, the size of the ring buffer, the logical position of the consumer, and the logical position of the producer. 
 
 ### Program types
 
@@ -75,5 +74,14 @@ This helper call can be used in the following program types:
 
 ### Example
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+```c
+long avail_data = 0;
+long ring_size = 0;
+long cons_pos = 0;
+long prod_pos = 0;
+
+avail_data = bpf_ringbuf_query(&my_ringbuf, BPF_RB_AVAIL_DATA);
+ring_size = bpf_ringbuf_query(&my_ringbuf, BPF_RB_RING_SIZE);
+cons_pos = bpf_ringbuf_query(&my_ringbuf, BPF_RB_CONS_POS);
+prod_pos = bpf_ringbuf_query(&my_ringbuf, BPF_RB_PROD_POS);
+```

--- a/docs/linux/helper-function/bpf_ringbuf_reserve.md
+++ b/docs/linux/helper-function/bpf_ringbuf_reserve.md
@@ -70,29 +70,12 @@ This helper call can be used in the following program types:
 ### Example
 
 ```c
-// Define the structure of the data to be stored in the ring buffer
-struct ringbuf_data {
-    __u64 timestamp;
-    __u32 pid;
-    char filename[512];
-};
-
-// Define a ring buffer map
-struct {
-    __uint(type, BPF_MAP_TYPE_RINGBUF);
-    __uint(max_entries, 256*1024);
-} my_ringbuf SEC(".maps");
-
-
-SEC("tp/syscalls/sys_enter_execve") 
-int get_pid_execve(struct trace_event_raw_sys_enter *ctx) {
-    // Reserve memory in the ring buffer
-    struct ringbuf_data *rb_data = bpf_ringbuf_reserve(&my_ringbuf, sizeof(struct ringbuf_data), 0);
-    if (! rb_data) {
-        // if bpf_ringbuf_reserve fails, print an error message and return
-        bpf_printk("bpf_ringbuf_reserve failed\n");
-        return 1;
-    }
-    ... // populate the rb_data struct with the required data
+struct ringbuf_data *rb_data = bpf_ringbuf_reserve(&my_ringbuf, sizeof(struct ringbuf_data), 0);
+if (! rb_data) {
+    // if bpf_ringbuf_reserve fails, print an error message and return
+    bpf_printk("bpf_ringbuf_reserve failed\n");
+    return 1;
 }
 ```
+
+Where `my_ringbuf` is the pointer to the ring buffer, and `ringbuf_data` is a struct that defines the structure of the data to be stored in the ring buffer. 

--- a/docs/linux/helper-function/bpf_ringbuf_reserve.md
+++ b/docs/linux/helper-function/bpf_ringbuf_reserve.md
@@ -29,6 +29,7 @@ The `rinfbuf` argument must be a pointer to a ring buffer definition. The `size`
 
 This function is generally used in combination with a `struct` that defines the structure of the data stored in the ring buffer. Hence, in this case, the `size` argument would be set to the size of the struct. The function returns a pointer to the reserved memory, which can be used to write data to the ring buffer. See the example below for more details. 
 
+Also check [bpf_ringbuf_submit](./bpf_ringbuf_submit.md) and [bpf_ringbuf_discard](./bpf_ringbuf_discard.md) for more information on how to handle the reserved memory in the ring buffer. 
 
 ### Program types
 

--- a/docs/linux/helper-function/bpf_ringbuf_submit.md
+++ b/docs/linux/helper-function/bpf_ringbuf_submit.md
@@ -27,8 +27,8 @@ Nothing. Always succeeds.
 
 ## Usage
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+Submit makes the data reserved in the ringbuf available for reading. The `data` argument must be a pointer to the reserved data in the ring buffer. 
+The `flags` argument declares how the notification of new data availability should be handled. 
 
 ### Program types
 
@@ -69,5 +69,15 @@ This helper call can be used in the following program types:
 
 ### Example
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+```c
+// Reserve space in the ring buffer
+struct ringbuf_data *rb_data = bpf_ringbuf_reserve(&my_ringbuf, sizeof(struct ringbuf_data), 0);
+
+// Fill the reserved data with some values
+rb_data->data = 42;
+rb_data->timestamp = bpf_ktime_get_ns();
+
+// Submit the reserved data
+bpf_ringbuf_submit(rb_data, 0);
+```
+

--- a/docs/linux/helper-function/bpf_ringbuf_submit.md
+++ b/docs/linux/helper-function/bpf_ringbuf_submit.md
@@ -72,6 +72,11 @@ This helper call can be used in the following program types:
 ```c
 // Reserve space in the ring buffer
 struct ringbuf_data *rb_data = bpf_ringbuf_reserve(&my_ringbuf, sizeof(struct ringbuf_data), 0);
+if(!rb_data) {
+    // if bpf_ringbuf_reserve fails, print an error message and return
+    bpf_printk("bpf_ringbuf_reserve failed\n");
+    return 1;
+}
 
 // Fill the reserved data with some values
 rb_data->data = 42;


### PR DESCRIPTION
- [x] bpf_ringbuf_reserve
- [x] bpf_ringbuf_submit
- [x] bpf_ringbuf_discard
- [x] bpf_ringbuf_output
- [x] bpf_ringbuf_query
- [ ] ~bpf_ringbuf_reserve_dynptr~
- [ ] ~bpf_ringbuf_submit_dynptr~
- [ ] ~bpf_ringbuf_discard_dynptr~