### PR TITLE
Add BPF CORE and BTF documentation

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,7 +6,7 @@
   * [Helper functions](linux/helper-function/)
   * [Syscall commands](linux/syscall/)
   * [KFuncs](linux/kfuncs/)
-* [Concepts](/docs/concepts/index.md)
+* [Concepts](concepts/index.md)
   * [BPF CO-RE](concepts/core.md)
   * [BTF](concepts/btf.md)
   * [ELF](concepts/elf.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -6,4 +6,8 @@
   * [Helper functions](linux/helper-function/)
   * [Syscall commands](linux/syscall/)
   * [KFuncs](linux/kfuncs/)
+* [Concepts](/docs/concepts/index.md)
+  * [BPF CO-RE](concepts/core.md)
+  * [BTF](concepts/btf.md)
+  * [ELF](concepts/elf.md)
 * [FAQ](faq.md)

--- a/docs/concepts/btf.md
+++ b/docs/concepts/btf.md
@@ -1,3 +1,16 @@
 # BTF
 
-<!-- TODO -->
+BTF (BPF Type Format) is a metadata format designed for encoding debug information related to BPF programs and maps. It focus on describing data types, function information for defined subroutines.
+This debug information serves various purposes including map visualization, function signature enhancement for BPF programs, and aiding in the generation of annotated source code, JITed code, and verifier logs.
+
+The BTF specification is divided into two main parts:
+
+* BTF Kernel API: This defines the interface between user space and the kernel. Before usage, the kernel validates the BTF information provided.
+* BTF ELF File Format: This establishes the contract between the ELF file and the libbpf loader in user space.
+
+It was created as an alternative to DWARF debug information. The BTF is more space-efficent due to his [deduplication algorithm] while remaining expressive enough to have all the type information of a C programs. 
+
+!!! example "Docs could be improved"
+    This part of the docs is incomplete, contributions are very welcome
+
+[deduplication algorithm]: https://nakryiko.com/posts/btf-dedup/

--- a/docs/concepts/core.md
+++ b/docs/concepts/core.md
@@ -1,9 +1,43 @@
-# CO-RE
+# BPF CO-RE
 
-<!-- What does co-re stand for -->
-<!-- Explain the problem -->
-<!-- CO-RE in compilers -->
-<!-- CO-RE eBPF library in libbpf -->
-<!-- CO-RE in ELF -->
-<!-- CO-RE in loaders -->
+BPF CO-RE stand for Compile Once - Run Everywhere
+It's a **concept** to build cross-version kernel eBPF application by building in a single binary by bringing together the [BTF] type information, libbpf and the compiler. 
+
+## Problem of portability
+eBPF programs use the memory and data structures from the kernel. Between different kernel versions, some structures can be modified, altering the memory layout. 
+Another problem can be the renaming of a field in the structure. 
+If a BPF application uses one of these modified or renamed fields, the program will no longer be compatible.
+
 <!-- CO-RE in the kernel + VMLinux -->
+## Export kernel informations
+Libbpf relie on the [BTF] information from the actual running Kernel who expose itself BTF information at `/sys/kernel/btf/vmlinux`.
+It include all kernel types and structures layout.
+A header file `vmlinux.h`, can be generate using [bpftool] :
+```sh
+bpftool btf dump file /sys/kernel/btf/vmlinux format c > vmlinux.h
+```
+
+This eliminate the depedency of the kernel headers
+
+<!-- CO-RE in compilers -->
+## Emit BTF relocations with Clang
+Clang was extended to emit BTF relocations. These relocations capture high-level descriptions of what information the BPF program intends to access.
+The compiled BPF program is stored in an ELF (Executable and Linkable Format) object file. This file contains BTF type information and Clang-generated relocations. 
+The ELF format allows libbpf to process and adjust the BPF program for the target kernel dynamically.
+
+<!-- CO-RE eBPF library in libbpf -->
+## Use Libbpf as CO-RE library and loader
+When you run your loader program with libbpf, it serves as the BPF program loader. It takes the compiled BPF ELF object file and post-processing it as necessary. It sets up various kernel objects (maps, programs, etc.) and triggers BPF program loading and verification. 
+Libbpf uses the BTF information to match the types and fields in the BPF program with those in the running kernel, adjusting offsets and other relocatable data to ensure the program functions correctly on the specific kernel.
+
+## Examples
+
+Lists of examples programs using libbpf can be found on Github [libbpf-bootstrap]
+
+!!! example "Docs could be improved"
+    This part of the docs is incomplete, contributions are very welcome
+
+
+[BTF]: btf.md
+[bpftool]: https://github.com/libbpf/bpftool
+[libbpf-bootstrap]: https://github.com/libbpf/libbpf-bootstrap

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,15 @@
+# Concepts
+
+## [BPF CO-RE] (Compile Once - Run Everywhere)
+It enables the development of portable BPF programs by integrating kernel BTF type information, Clang compiler support for relocation, and libbpf loader adjustments, ensuring compatibility across different kernel versions without runtime compilation overhead.
+
+[BPF CO-RE]: core.md
+
+## [BTF] (BPF Type Format)
+It is compact, efficient format for describing C program type information. It enables runtime accessibility of kernel types crucial for BPF program development and verification.
+
+[BTF]: btf.md
+
+## [ELF]
+
+[ELF]: elf.md


### PR DESCRIPTION
I take the plunge.
I've tried to synthetize without losing as much detail as possible 

- Add documentation for BPF CO-RE
- Add documentation for BTF

There are still a few things missing:

- [ ] Examples of using libbpf CO-RE functions
- [ ] Add all libbpf CO-RE functions 
- [ ] ELF documentation

Questions about files : `instruction-set.md` and `loader.md` what is expected ?
