### PR TITLE
Improve Dockerfile caching in CI

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -49,7 +49,7 @@ jobs:
           echo "    property: G-KVJ1CK539N" >> mkdocs.yml
       - name: Build html
         run: |
-          make html PROD=true GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          make html PROD=true GH_TOKEN=${{ secrets.GITHUB_TOKEN }} GHA_CACHE=true CONTAINER_ENGINE=docker
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -13,7 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-            
       - name: Run spellcheck
         run: |
-          make spellcheck
+          make spellcheck GHA_CACHE=true CONTAINER_ENGINE=docker
+      - # Temp fix
+        # https://github.com/docker/build-push-action/issues/252
+        # https://github.com/moby/buildkit/issues/1896
+        name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache          
 

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -9,4 +9,4 @@ RUN apt update && \
     pip install -r /root/requirements.txt && \
     groupadd -g $GID docs || true && \
     useradd -u $UID -g $GID -m -s /bin/bash docs || true
-ENTRYPOINT bash
+ENTRYPOINT ["bash"]


### PR DESCRIPTION
Currently our docker image is constantly rebuilding because the docker layers are not cached between CI runs. These changes should tell docker to use the Github Actions cache to store the docker layers between runs.