### PR TITLE
Add social cards to the website

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Apply deploy config
         run: |
           echo "" >> mkdocs.yml
-          echo "site_url: https://isovalent.github.io" >> mkdocs.yml
+          echo "site_url: https://docs.ebpf.io" >> mkdocs.yml
           echo "" >> mkdocs.yml
           echo "extra:" >> mkdocs.yml
           echo "  analytics:" >> mkdocs.yml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,9 @@ plugins:
       token: !ENV ["GH_TOKEN"]
       repository: isovalent/ebpf-docs
       branch: master
+  - social:
+      cards_layout_options:
+        logo: docs/assets/image/logo.png
 
 extra_css:
   - stylesheets/extra.css

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 mkdocs >= 1.6.0, <= 1.7.0
 mkdocs-material == 9.*
+mkdocs-material[imaging]
 mkdocs-literate-nav == 0.6.1
 mkdocs-git-revision-date-localized-plugin >= 1.2.0, <= 1.3.0
 mkdocs-git-committers-plugin-2 >= 2.3.0, <= 2.4.0

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -5,7 +5,8 @@ ARG GID=1000
 
 COPY requirements.txt /root/requirements.txt
 RUN apt update && \
-    apt install -y git aspell && \
+    apt install -y git aspell libcairo2-dev libfreetype6-dev libffi-dev \
+        libjpeg-dev libpng-dev libz-dev && \
     pip install -r /root/requirements.txt && \
     groupadd -g $GID docs || true && \
     useradd -u $UID -g $GID -m -s /bin/bash docs || true


### PR DESCRIPTION
This commit adds the `social` plugin which generates social cards for every page. These are essentially PNG images which will be displayed when the page is shared on social media platforms.

This is just the basic setup to get something going.