### PR TITLE
helper-functions: Update `bpf_get_attach_cookie` info

### DIFF
--- a/data/helpers-functions.yaml
+++ b/data/helpers-functions.yaml
@@ -128,6 +128,10 @@ groups:
     prog_trampoline: true
   - name: bpf_get_func_arg_cnt
     prog_trampoline: true
+  - name: bpf_get_attach_cookie
+    since:
+      version: 5.19
+      commit: 2fcc82411e74e5e6aba336561cf56fb899bfae4e
   - group: raw_tp
   - group: bpf_iter
     attach_type: [BPF_TRACE_ITER]
@@ -646,6 +650,7 @@ programs:
 
   # `raw_tp_prog_func_proto` in `kernel/tracing/bpf_trace.c`
   BPF_PROG_TYPE_RAW_TRACEPOINT:
+  - name: bpf_get_attach_cookie
   - group: raw_tp
 
   # `sock_addr_func_proto` in `net/core/filter.c`
@@ -789,7 +794,7 @@ programs:
     kconfig: [CONFIG_INET]
   - group: cgroup_base
 
-  # `tracing_prog_func_proto` in `kernel/tracing/bpf_trace.c`
+  # `tracing_prog_func_proto` in `kernel/trace/bpf_trace.c`
   BPF_PROG_TYPE_TRACING:
   - group: tracing_prog
 
@@ -828,6 +833,10 @@ programs:
     since:
       version: 6.0
       commit: 9113d7e48e9128522b9f5a54dfd30dff10509a92
+  - name: bpf_get_attach_cookie
+    since:
+      version: 5.19
+      commit: 2fcc82411e74e5e6aba336561cf56fb899bfae4e
   - group: tracing
 
   # TODO

--- a/docs/linux/helper-function/bpf_get_attach_cookie.md
+++ b/docs/linux/helper-function/bpf_get_attach_cookie.md
@@ -13,22 +13,21 @@ description: "This page documents the 'bpf_get_attach_cookie' eBPF helper functi
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.
 
 
-<!-- [HELPER_FUNC_DEF] -->
 Get bpf_cookie value provided (optionally) during the program attachment. It might be different for each individual attachment, even if BPF program itself is the same. Expects BPF program context _ctx_ as a first argument.
 
 Supported for the following program types:
 
-&nbsp;&nbsp;&nbsp;&nbsp;- kprobe/uprobe;
-&nbsp;- tracepoint;
-&nbsp;- perf_event.
-
+- kprobe/uprobe
+- tracepoint
+- perf_event
+- <nospell>fentry/fexit/fmod_ret</nospell>
+- LSM
 
 ### Returns
 
 Value specified by user at BPF link creation/attachment time or 0, if it was not specified.
 
 `#!c static __u64 (* const bpf_get_attach_cookie)(void *ctx) = (void *) 174;`
-<!-- [/HELPER_FUNC_DEF] -->
 
 ## Usage
 
@@ -41,8 +40,11 @@ This helper call can be used in the following program types:
 <!-- DO NOT EDIT MANUALLY -->
 <!-- [HELPER_FUNC_PROG_REF] -->
  * [`BPF_PROG_TYPE_KPROBE`](../program-type/BPF_PROG_TYPE_KPROBE.md)
+ * [`BPF_PROG_TYPE_LSM`](../program-type/BPF_PROG_TYPE_LSM.md) [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/2fcc82411e74e5e6aba336561cf56fb899bfae4e)
  * [`BPF_PROG_TYPE_PERF_EVENT`](../program-type/BPF_PROG_TYPE_PERF_EVENT.md)
+ * [`BPF_PROG_TYPE_RAW_TRACEPOINT`](../program-type/BPF_PROG_TYPE_RAW_TRACEPOINT.md)
  * [`BPF_PROG_TYPE_TRACEPOINT`](../program-type/BPF_PROG_TYPE_TRACEPOINT.md)
+ * [`BPF_PROG_TYPE_TRACING`](../program-type/BPF_PROG_TYPE_TRACING.md) [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/2fcc82411e74e5e6aba336561cf56fb899bfae4e)
 <!-- [/HELPER_FUNC_PROG_REF] -->
 
 ### Example

--- a/docs/linux/program-type/BPF_PROG_TYPE_LSM.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_LSM.md
@@ -71,6 +71,7 @@ Not all helper functions are available in all program types. These are the helpe
     * [`bpf_ima_file_hash`](../helper-function/bpf_ima_file_hash.md)
     * [`bpf_setsockopt`](../helper-function/bpf_setsockopt.md) [:octicons-tag-24: v6.0](https://github.com/torvalds/linux/commit/9113d7e48e9128522b9f5a54dfd30dff10509a92)
     * [`bpf_getsockopt`](../helper-function/bpf_getsockopt.md) [:octicons-tag-24: v6.0](https://github.com/torvalds/linux/commit/9113d7e48e9128522b9f5a54dfd30dff10509a92)
+    * [`bpf_get_attach_cookie`](../helper-function/bpf_get_attach_cookie.md) [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/2fcc82411e74e5e6aba336561cf56fb899bfae4e)
     * [`bpf_map_lookup_elem`](../helper-function/bpf_map_lookup_elem.md)
     * [`bpf_map_update_elem`](../helper-function/bpf_map_update_elem.md)
     * [`bpf_map_delete_elem`](../helper-function/bpf_map_delete_elem.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_RAW_TRACEPOINT.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_RAW_TRACEPOINT.md
@@ -229,6 +229,7 @@ Not all helper functions are available in all program types. These are the helpe
 <!-- DO NOT EDIT MANUALLY -->
 <!-- [PROG_HELPER_FUNC_REF] -->
 ??? abstract "Supported helper functions"
+    * [`bpf_get_attach_cookie`](../helper-function/bpf_get_attach_cookie.md)
     * [`bpf_perf_event_output`](../helper-function/bpf_perf_event_output.md)
     * [`bpf_get_stackid`](../helper-function/bpf_get_stackid.md)
     * [`bpf_get_stack`](../helper-function/bpf_get_stack.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_TRACING.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_TRACING.md
@@ -375,6 +375,7 @@ Not all helper functions are available in all program types. These are the helpe
     * [`bpf_get_func_arg`](../helper-function/bpf_get_func_arg.md)
     * [`bpf_get_func_ret`](../helper-function/bpf_get_func_ret.md)
     * [`bpf_get_func_arg_cnt`](../helper-function/bpf_get_func_arg_cnt.md)
+    * [`bpf_get_attach_cookie`](../helper-function/bpf_get_attach_cookie.md) [:octicons-tag-24: v5.19](https://github.com/torvalds/linux/commit/2fcc82411e74e5e6aba336561cf56fb899bfae4e)
     * [`bpf_perf_event_output`](../helper-function/bpf_perf_event_output.md)
     * [`bpf_get_stackid`](../helper-function/bpf_get_stackid.md)
     * [`bpf_get_stack`](../helper-function/bpf_get_stack.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ plugins:
       repository: isovalent/ebpf-docs
       branch: master
   - social:
+      enabled: !ENV [PROD, false]
       cards_layout_options:
         logo: docs/assets/image/logo.png
 


### PR DESCRIPTION
In v5.19, cookie support was added to `BPF_PROG_TYPE_TRACING` and `BPF_PROG_TYPE_LSM`. This isn't reflected in the man pages and wasn't in our docs. This commit fixes both the description and program <-> helper function indexes.