### PR TITLE
libbpf/ebpf: Add attribute macros pages

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -126,6 +126,7 @@ relocation
 relocations
 signable
 accumulatively
+untrusted
 inlined
 lifecycle
 nginx

--- a/docs/ebpf-library/libbpf/ebpf/SUMMARY.md
+++ b/docs/ebpf-library/libbpf/ebpf/SUMMARY.md
@@ -5,3 +5,13 @@
   - [`__array`](__array.md)
   - [`__ulong`](__ulong.md)
   - [`enum libbpf_pin_type`](enum-libbpf_pin_type.md)
+- Attributes
+  - [`__always_inline`](__always_inline.md)
+  - [`__noinline`](__noinline.md)
+  - [`__weak`](__weak.md)
+  - [`__hidden`](__hidden.md)
+  - [`__kconfig`](__kconfig.md)
+  - [`__ksym`](__ksym.md)
+  - [`__kptr_untrusted`](__kptr_untrusted.md)
+  - [`__kptr`](__kptr.md)
+  - [`__percpu_kptr`](__percpu_kptr.md)

--- a/docs/ebpf-library/libbpf/ebpf/__always_inline.md
+++ b/docs/ebpf-library/libbpf/ebpf/__always_inline.md
@@ -1,0 +1,39 @@
+---
+title: "Libbpf eBPF macro '__always_inline'"
+description: "This page documents the '__always_inline' libbpf eBPF macro, including its definition, usage, and examples."
+---
+# Libbpf eBPF macro `__always_inline`
+
+[:octicons-tag-24: v0.0.6](https://github.com/libbpf/libbpf/releases/tag/v0.0.6)
+
+The `__always_inline` macros is used to tell the compiler to inline a function.
+
+## Definition
+
+`#!c #define __always_inline inline __attribute__((always_inline))`
+
+## Usage
+
+This macro is used to tell the compiler to inline a function. This is a best attempt at "forcing" the compiler to inline a function. The combination of the C `inline` keyword and the `__attribute__((always_inline))` attribute gives the strongest hint possible to the compiler that the function should be inlined.
+
+This is particularly useful when writing eBPF programs, for kernel version that do not support BPF-to-BPF functions or when they are unwanted for performance reasons.
+
+It should be noted that the Clang docs states that the `always_inline` attribute is not a guarantee that the function will be inlined.
+
+### Example
+
+```c hl_lines="1"
+static int __always_inline add(int a, int b)
+{
+    return a + b;
+}
+
+SEC("xdp")
+int example_prog(struct xdp_md *ctx)
+{
+    if (add(1, 2) == 3)
+        return XDP_PASS;
+    else
+        return XDP_DROP;
+}
+```

--- a/docs/ebpf-library/libbpf/ebpf/__hidden.md
+++ b/docs/ebpf-library/libbpf/ebpf/__hidden.md
@@ -1,0 +1,37 @@
+---
+title: "Libbpf eBPF macro '__hidden'"
+description: "This page documents the '__hidden' libbpf eBPF macro, including its definition, usage, and examples."
+---
+# Libbpf eBPF macro `__hidden`
+
+[:octicons-tag-24: v0.4.0](https://github.com/libbpf/libbpf/releases/tag/v0.4.0)
+
+The `__hidden` macros is used make a symbol as hidden.
+
+## Definition
+
+`#!c #define __hidden __attribute__((visibility("hidden")))`
+
+## Usage
+
+This macro is used to mark a symbol as hidden. This can be used for two thing. First, if applied on a global function, the loader (library) will modify the BTF to tell the verifier its a static function. This triggers different BPF-to-BPF function verification, see [Function by function verification](../../../linux/concepts/functions.md#function-by-function-verification).
+
+The second use case is that when applied to global variables, they will be hidden from userspace, effectively making them eBPF only.
+
+### Example
+
+In this example we use `__hidden` since userspace should not interfere with the spinlock, which is only used by eBPF programs. However, this is a very bad example, please to not use them this way in practice.
+
+```c hl_lines="1"
+struct bpf_spin_lock lockA __hidden SEC(".data.A");
+int counter = 0;
+
+SEC("xdp")
+int example_prog(struct xdp_md *ctx)
+{
+    bpf_spin_lock(&lockA);
+    counter++;
+    bpf_spin_unlock(&lockA);
+	return XDP_PASS;
+}
+```

--- a/docs/ebpf-library/libbpf/ebpf/__kconfig.md
+++ b/docs/ebpf-library/libbpf/ebpf/__kconfig.md
@@ -1,0 +1,56 @@
+---
+title: "Libbpf eBPF macro '__kconfig'"
+description: "This page documents the '__kconfig' libbpf eBPF macro, including its definition, usage, and examples."
+---
+# Libbpf eBPF macro `__kconfig`
+
+[:octicons-tag-24: v0.0.7](https://github.com/libbpf/libbpf/releases/tag/v0.0.7)
+
+The `__kconfig` macros is used to instruct the loader to provide the value of a kernel configuration of the system the program is being loaded on to the program.
+
+## Definition
+
+`#!c #define __kconfig __attribute__((section(".kconfig")))`
+
+## Usage
+
+This macro places a global variable in the `.kconfig` section of the eBPF object file. This will signal the loader (library) to initialize the value of the variable to the value of the kernel configuration option with the same name as the variable. Since kernel configuration values can be `y`, `m`, or `n`, the variable will be initialized to enum values instead.
+
+```c
+enum libbpf_tristate {
+	TRI_NO = 0,
+	TRI_YES = 1,
+	TRI_MODULE = 2,
+};
+```
+
+This enum type is also provided by the `bpf_helpers.h` file. 
+
+This capability ties into CO-RE (Compile Once - Run Everywhere). Since the value is provided at load time it allows the user to write multiple variations / code paths that are enabled or disabled based on the value of, for example, in this case a kernel configuration option. Therefor allowing the same pre-compiled eBPF program to be loaded on different systems with different kernel configurations.
+
+If a value for a kernel configuration option is not found, the loader (library) will error out, unless the [`__weak`](__weak.md) attribute is also used.
+
+### Example
+
+```c hl_lines="1"
+extern unsigned CONFIG_HZ __kconfig;
+
+#define USER_HZ		100
+#define NSEC_PER_SEC	1000000000ULL
+static clock_t jiffies_to_clock_t(unsigned long x)
+{
+	/* The implementation here tailored to a particular
+	 * setting of USER_HZ.
+	 */
+	u64 tick_nsec = (NSEC_PER_SEC + CONFIG_HZ/2) / CONFIG_HZ;
+	u64 user_hz_nsec = NSEC_PER_SEC / USER_HZ;
+
+	if ((tick_nsec % user_hz_nsec) == 0) {
+		if (CONFIG_HZ < USER_HZ)
+			return x * (USER_HZ / CONFIG_HZ);
+		else
+			return x / (CONFIG_HZ / USER_HZ);
+	}
+	return x * tick_nsec/user_hz_nsec;
+}
+```

--- a/docs/ebpf-library/libbpf/ebpf/__kptr.md
+++ b/docs/ebpf-library/libbpf/ebpf/__kptr.md
@@ -1,0 +1,83 @@
+---
+title: "Libbpf eBPF macro '__kptr'"
+description: "This page documents the '__kptr' libbpf eBPF macro, including its definition, usage, and examples."
+---
+# Libbpf eBPF macro `__kptr`
+
+[:octicons-tag-24: v0.8.0](https://github.com/libbpf/libbpf/releases/tag/v0.8.0)
+
+The `__kptr` macros is used to tag a pointer to tell the verifier it holds pointers to kernel memory.
+
+## Definition
+
+`#!c #define __kptr __attribute__((btf_type_tag("kptr")))`
+
+## Usage
+
+This macro can used on type definitions for both global variables and fields in map values. It informs the verifier that the pointer is a kernel pointer.
+
+!!! example "Docs could be improved"
+    This part of the docs is incomplete, contributions are very welcome 
+
+### Example
+
+```c hl_lines="2"
+struct cpumask_map_value {
+        struct bpf_cpumask __kptr * cpumask;
+};
+
+struct array_map {
+        __uint(type, BPF_MAP_TYPE_ARRAY);
+        __type(key, int);
+        __type(value, struct cpumask_map_value);
+        __uint(max_entries, 65536);
+} cpumask_map SEC(".maps");
+
+static int cpumask_map_insert(struct bpf_cpumask *mask, u32 pid)
+{
+        struct cpumask_map_value local, *v;
+        long status;
+        struct bpf_cpumask *old;
+        u32 key = pid;
+
+        local.cpumask = NULL;
+        status = bpf_map_update_elem(&cpumask_map, &key, &local, 0);
+        if (status) {
+                bpf_cpumask_release(mask);
+                return status;
+        }
+
+        v = bpf_map_lookup_elem(&cpumask_map, &key);
+        if (!v) {
+                bpf_cpumask_release(mask);
+                return -ENOENT;
+        }
+
+        old = bpf_kptr_xchg(&v->cpumask, mask);
+        if (old)
+                bpf_cpumask_release(old);
+
+        return 0;
+}
+
+/**
+    * A sample tracepoint showing how a task's cpumask can be queried and
+    * recorded as a kptr.
+    */
+SEC("tp_btf/task_newtask")
+int BPF_PROG(record_task_cpumask, struct task_struct *task, u64 clone_flags)
+{
+        struct bpf_cpumask *cpumask;
+        int ret;
+
+        cpumask = bpf_cpumask_create();
+        if (!cpumask)
+                return -ENOMEM;
+
+        if (!bpf_cpumask_full(task->cpus_ptr))
+                bpf_printk("task %s has CPU affinity", task->comm);
+
+        bpf_cpumask_copy(cpumask, task->cpus_ptr);
+        return cpumask_map_insert(cpumask, task->pid);
+}
+```

--- a/docs/ebpf-library/libbpf/ebpf/__kptr_untrusted.md
+++ b/docs/ebpf-library/libbpf/ebpf/__kptr_untrusted.md
@@ -1,0 +1,75 @@
+---
+title: "Libbpf eBPF macro '__kptr_untrusted'"
+description: "This page documents the '__kptr_untrusted' libbpf eBPF macro, including its definition, usage, and examples."
+---
+# Libbpf eBPF macro `__kptr_untrusted`
+
+[:octicons-tag-24: v1.2.0](https://github.com/libbpf/libbpf/releases/tag/v1.2.0)
+
+The `__kptr_untrusted` macros is used to tag a pointer to tell the verifier it holds untrusted pointers to kernel memory.
+
+## Definition
+
+`#!c #define __kptr_untrusted __attribute__((btf_type_tag("kptr_untrusted")))`
+
+## Usage
+
+This macro can used on type definitions for both global variables and fields in map values. It informs the verifier that the pointer is a untrusted kernel pointer. 
+
+!!! example "Docs could be improved"
+    This part of the docs is incomplete, contributions are very welcome 
+
+### Example
+
+```c hl_lines="7"
+// SPDX-License-Identifier: GPL-2.0
+#include <vmlinux.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/bpf_helpers.h>
+
+struct map_value {
+	struct task_struct __kptr_untrusted *ptr;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LRU_HASH);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct map_value);
+} lru_map SEC(".maps");
+
+int pid = 0;
+int result = 1;
+
+SEC("fentry/bpf_ktime_get_ns")
+int printk(void *ctx)
+{
+	struct map_value v = {};
+
+	if (pid == bpf_get_current_task_btf()->pid)
+		bpf_map_update_elem(&lru_map, &(int){0}, &v, 0);
+	return 0;
+}
+
+SEC("fentry/do_nanosleep")
+int nanosleep(void *ctx)
+{
+	struct map_value val = {}, *v;
+	struct task_struct *current;
+
+	bpf_map_update_elem(&lru_map, &(int){0}, &val, 0);
+	v = bpf_map_lookup_elem(&lru_map, &(int){0});
+	if (!v)
+		return 0;
+	bpf_map_delete_elem(&lru_map, &(int){0});
+	current = bpf_get_current_task_btf();
+	v->ptr = current;
+	pid = current->pid;
+	bpf_ktime_get_ns();
+	result = !v->ptr;
+	return 0;
+}
+
+char _license[] SEC("license") = "GPL";
+
+```

--- a/docs/ebpf-library/libbpf/ebpf/__ksym.md
+++ b/docs/ebpf-library/libbpf/ebpf/__ksym.md
@@ -1,0 +1,71 @@
+---
+title: "Libbpf eBPF macro '__ksym'"
+description: "This page documents the '__ksym' libbpf eBPF macro, including its definition, usage, and examples."
+---
+# Libbpf eBPF macro `__ksym`
+
+[:octicons-tag-24: v0.1.0](https://github.com/libbpf/libbpf/releases/tag/v0.1.0)
+
+The `__ksym` macros is used to instruct the loader to provide the memory address of a kernel symbol.
+
+## Definition
+
+`#!c #define __ksym __attribute__((section(".ksyms")))`
+
+## Usage
+
+This macro tells the compiler to put the variable in the `.ksyms` section of the eBPF object file. This signals the loader (library) to initialize the value of the variable to the memory address of the kernel symbol with the same name as the variable.
+
+When the defined variable of of the type `void *`, the loader will only consider the name of the kernel symbol. If it is a pointer to an explicit type, then the loader will use BTF to verify the type of the symbol.
+
+An example use case for this feature would be to get the address of a global variable in the kernel and use [`bpf_probe_read_kernel`](../../../linux/helper-function/bpf_probe_read_kernel.md) to read its value.
+
+The `__ksym` macro is also part of every [kfunc](../../../linux/concepts/kfuncs.md) definition, here it purpose is very similar. It instructs the loader to provide the memory address of the kernel function with the same type.
+
+In both the variable and function case, if the symbol is not found, the loader (library) will error out, unless the [`__weak`](__weak.md) attribute is also used.
+
+!!! note
+    The Clang eBPF backend will actually omit the actual ELF section, but the data section still exists in the BTF type info and relocation entries.
+
+### Example
+
+```c hl_lines="8"
+// SPDX-License-Identifier: GPL-2.0
+/* Copyright (C) 2022. Huawei Technologies Co., Ltd */
+#include "vmlinux.h"
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+
+extern bool CONFIG_PREEMPT __kconfig __weak;
+extern const int bpf_task_storage_busy __ksym;
+
+char _license[] SEC("license") = "GPL";
+
+int pid = 0;
+int busy = 0;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_TASK_STORAGE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+	__type(key, int);
+	__type(value, long);
+} task SEC(".maps");
+
+SEC("raw_tp/sys_enter")
+int BPF_PROG(read_bpf_task_storage_busy)
+{
+	int *value;
+
+	if (!CONFIG_PREEMPT)
+		return 0;
+
+	if (bpf_get_current_pid_tgid() >> 32 != pid)
+		return 0;
+
+	value = bpf_this_cpu_ptr(&bpf_task_storage_busy);
+	if (value)
+		busy = *value;
+
+	return 0;
+}
+```

--- a/docs/ebpf-library/libbpf/ebpf/__noinline.md
+++ b/docs/ebpf-library/libbpf/ebpf/__noinline.md
@@ -1,0 +1,35 @@
+---
+title: "Libbpf eBPF macro '__noinline'"
+description: "This page documents the '__noinline' libbpf eBPF macro, including its definition, usage, and examples."
+---
+# Libbpf eBPF macro `__noinline`
+
+[:octicons-tag-24: v0.2](https://github.com/libbpf/libbpf/releases/tag/v0.2)
+
+The `__noinline` macros is used to tell the compiler to inline a function.
+
+## Definition
+
+`#!c #define __noinline __attribute__((noinline))`
+
+## Usage
+
+This macro is used to tell the compiler to not inline a function. This is mainly useful to force the use of a BPF-to-BPF function call. This might be important if you are at the limit of stack space in calling functions.
+
+### Example
+
+```c hl_lines="1"
+static int __noinline add(int a, int b)
+{
+    return a + b;
+}
+
+SEC("xdp")
+int example_prog(struct xdp_md *ctx)
+{
+    if (add(1, 2) == 3)
+        return XDP_PASS;
+    else
+        return XDP_DROP;
+}
+```

--- a/docs/ebpf-library/libbpf/ebpf/__percpu_kptr.md
+++ b/docs/ebpf-library/libbpf/ebpf/__percpu_kptr.md
@@ -1,0 +1,215 @@
+---
+title: "Libbpf eBPF macro '__percpu_kptr'"
+description: "This page documents the '__percpu_kptr' libbpf eBPF macro, including its definition, usage, and examples."
+---
+# Libbpf eBPF macro `__percpu_kptr`
+
+[:octicons-tag-24: v1.3.0](https://github.com/libbpf/libbpf/releases/tag/v1.3.0)
+
+The `__percpu_kptr` macros is used to tag a pointer to tell the verifier it holds per-CPU pointers to kernel memory.
+
+## Definition
+
+`#!c #define __percpu_kptr __attribute__((btf_type_tag("percpu_kptr")))`
+
+## Usage
+
+This macro can used on type definitions for both global variables and fields in map values. It informs the verifier that the pointer is a per-CPU kernel pointer. 
+
+!!! example "Docs could be improved"
+    This part of the docs is incomplete, contributions are very welcome 
+
+### Example
+
+```c hl_lines="9"
+#include "bpf_experimental.h"
+
+struct val_t {
+	long b, c, d;
+};
+
+struct elem {
+	long sum;
+	struct val_t __percpu_kptr *pc;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, int);
+	__type(value, struct elem);
+} array SEC(".maps");
+
+void bpf_rcu_read_lock(void) __ksym;
+void bpf_rcu_read_unlock(void) __ksym;
+
+const volatile int nr_cpus;
+
+/* Initialize the percpu object */
+SEC("?fentry/bpf_fentry_test1")
+int BPF_PROG(test_array_map_1)
+{
+	struct val_t __percpu_kptr *p;
+	struct elem *e;
+	int index = 0;
+
+	e = bpf_map_lookup_elem(&array, &index);
+	if (!e)
+		return 0;
+
+	p = bpf_percpu_obj_new(struct val_t);
+	if (!p)
+		return 0;
+
+	p = bpf_kptr_xchg(&e->pc, p);
+	if (p)
+		bpf_percpu_obj_drop(p);
+
+	return 0;
+}
+
+/* Update percpu data */
+SEC("?fentry/bpf_fentry_test2")
+int BPF_PROG(test_array_map_2)
+{
+	struct val_t __percpu_kptr *p;
+	struct val_t *v;
+	struct elem *e;
+	int index = 0;
+
+	e = bpf_map_lookup_elem(&array, &index);
+	if (!e)
+		return 0;
+
+	p = e->pc;
+	if (!p)
+		return 0;
+
+	v = bpf_per_cpu_ptr(p, 0);
+	if (!v)
+		return 0;
+	v->c = 1;
+	v->d = 2;
+
+	return 0;
+}
+
+int cpu0_field_d, sum_field_c;
+int my_pid;
+
+/* Summarize percpu data */
+SEC("?fentry/bpf_fentry_test3")
+int BPF_PROG(test_array_map_3)
+{
+	struct val_t __percpu_kptr *p;
+	int i, index = 0;
+	struct val_t *v;
+	struct elem *e;
+
+	if ((bpf_get_current_pid_tgid() >> 32) != my_pid)
+		return 0;
+
+	e = bpf_map_lookup_elem(&array, &index);
+	if (!e)
+		return 0;
+
+	p = e->pc;
+	if (!p)
+		return 0;
+
+	bpf_for(i, 0, nr_cpus) {
+		v = bpf_per_cpu_ptr(p, i);
+		if (v) {
+			if (i == 0)
+				cpu0_field_d = v->d;
+			sum_field_c += v->c;
+		}
+	}
+
+	return 0;
+}
+
+/* Explicitly free allocated percpu data */
+SEC("?fentry/bpf_fentry_test4")
+int BPF_PROG(test_array_map_4)
+{
+	struct val_t __percpu_kptr *p;
+	struct elem *e;
+	int index = 0;
+
+	e = bpf_map_lookup_elem(&array, &index);
+	if (!e)
+		return 0;
+
+	/* delete */
+	p = bpf_kptr_xchg(&e->pc, NULL);
+	if (p) {
+		bpf_percpu_obj_drop(p);
+	}
+
+	return 0;
+}
+
+SEC("?fentry.s/bpf_fentry_test1")
+int BPF_PROG(test_array_map_10)
+{
+	struct val_t __percpu_kptr *p, *p1;
+	int i, index = 0;
+	struct val_t *v;
+	struct elem *e;
+
+	if ((bpf_get_current_pid_tgid() >> 32) != my_pid)
+		return 0;
+
+	e = bpf_map_lookup_elem(&array, &index);
+	if (!e)
+		return 0;
+
+	bpf_rcu_read_lock();
+	p = e->pc;
+	if (!p) {
+		p = bpf_percpu_obj_new(struct val_t);
+		if (!p)
+			goto out;
+
+		p1 = bpf_kptr_xchg(&e->pc, p);
+		if (p1) {
+			/* race condition */
+			bpf_percpu_obj_drop(p1);
+		}
+	}
+
+	v = bpf_this_cpu_ptr(p);
+	v->c = 3;
+	v = bpf_this_cpu_ptr(p);
+	v->c = 0;
+
+	v = bpf_per_cpu_ptr(p, 0);
+	if (!v)
+		goto out;
+	v->c = 1;
+	v->d = 2;
+
+	/* delete */
+	p1 = bpf_kptr_xchg(&e->pc, NULL);
+	if (!p1)
+		goto out;
+
+	bpf_for(i, 0, nr_cpus) {
+		v = bpf_per_cpu_ptr(p, i);
+		if (v) {
+			if (i == 0)
+				cpu0_field_d = v->d;
+			sum_field_c += v->c;
+		}
+	}
+
+	/* finally release p */
+	bpf_percpu_obj_drop(p1);
+out:
+	bpf_rcu_read_unlock();
+	return 0;
+}
+
+char _license[] SEC("license") = "GPL";
+```

--- a/docs/ebpf-library/libbpf/ebpf/__weak.md
+++ b/docs/ebpf-library/libbpf/ebpf/__weak.md
@@ -1,0 +1,58 @@
+---
+title: "Libbpf eBPF macro '__weak'"
+description: "This page documents the '__weak' libbpf eBPF macro, including its definition, usage, and examples."
+---
+# Libbpf eBPF macro `__weak`
+
+[:octicons-tag-24: v0.0.7](https://github.com/libbpf/libbpf/releases/tag/v0.0.7)
+
+The `__weak` macros is used to mark a symbol is weak.
+
+## Definition
+
+`#!c #define __weak __attribute__((weak))`
+
+## Usage
+
+This macro is used mark a symbol as being "weak" as apposed to normal symbols which are "strong". Originally, this property was used to inform the linker when linking together multiple object files. A weak symbol can be overridden by a strong symbol from another object file. So in a sense it is a way to provide a default implementation that can be overridden depending on which files are linked together.
+
+In the context of eBPF we do not typically link multiple object files together. Here it is used to tell the loader (library) to do a best effort to provide some sort of information. For example a kernel symbol or kfunc. Normally, a loader will throw an error if it cannot find a symbol, but by marking a symbol as weak, the user can tell the loader to tolerate the symbol not being found and continue anyway. The eBPF program is expected to handle the case where the symbol is not found.
+
+Another side effect of marking a symbol as weak is that the compiler cannot make assumptions about the contents of the symbol. This makes inlining or other optimizations impossible. And since a linker is supposed to know about the existence of weak symbols, they are always emitted in the object file, even if they are not used. Sometimes developers might mark a symbol as weak for these reasons.
+
+### Example
+
+In this example we mark the `bpf_dynptr_from_xdp` function as weak. If the function is not found, its value is `NULL`. We can check with an if statement if the function is available and use it if it is.
+Otherwise we fall back to an older way of accessing the data.
+
+```c hl_lines="1"
+extern int bpf_dynptr_from_xdp(struct xdp_md *x, u64 flags, struct bpf_dynptr *ptr__uninit) __weak __ksym;
+
+SEC("xdp.frags")
+int example_prog(struct xdp_md *ctx)
+{
+    if (bpf_dynptr_from_xdp) {
+        struct bpf_dynptr ptr;
+        if (bpf_dynptr_from_xdp(ctx, 0, &ptr) < 0)
+            return XDP_DROP;
+
+        __u8 buf[sizeof(struct ethhdr)];
+        struct ethhdr *eth = bpf_dynptr_slice(&ptr, buf, sizeof(buf));
+        if (!eth)
+            return XDP_DROP;
+
+        if (eth->h_proto == htons(ETH_P_IP))
+            return XDP_PASS;
+    } else {
+        void *data_end = (void *)(long)ctx->data_end;
+        void *data = (void *)(long)ctx->data;
+
+        if (data + sizeof(struct ethhdr) > data_end)
+            return XDP_DROP;
+
+        struct ethhdr *eth = data;
+        if (eth->h_proto == htons(ETH_P_IP))
+            return XDP_PASS;
+    }
+}
+```

--- a/docs/ebpf-library/libbpf/ebpf/index.md
+++ b/docs/ebpf-library/libbpf/ebpf/index.md
@@ -34,15 +34,15 @@ The file contains definitions for the following:
     * [`enum libbpf_pin_type`](enum-libbpf_pin_type.md)
 * `SEC`
 * Attributes
-    * `__always_inline`
-    * `__noinline`
-    * `__weak`
-    * `__hidden`
-    * `__kconfig`
-    * `__ksym`
-    * `__kptr_untrusted`
-    * `__kptr`
-    * `__percpu_kptr`
+    * [`__always_inline`](__always_inline.md)
+    * [`__noinline`](__noinline.md)
+    * [`__weak`](__weak.md)
+    * [`__hidden`](__hidden.md)
+    * [`__kconfig`](__kconfig.md)
+    * [`__ksym`](__ksym.md)
+    * [`__kptr_untrusted`](__kptr_untrusted.md)
+    * [`__kptr`](__kptr.md)
+    * [`__percpu_kptr`](__percpu_kptr.md)
 * `NULL`
 * `KERNEL_VERSION`
 * `offsetof`


### PR DESCRIPTION
This commit adds pages for the __xxx attribute macros that are available in the bpf_helpers.h header file.