### PR TITLE
.github/workflows: Git safe directory

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -49,6 +49,7 @@ jobs:
           echo "    property: G-KVJ1CK539N" >> mkdocs.yml
       - name: Build html
         run: |
+          git config --add safe.directory /docs
           make html PROD=true GH_TOKEN=${{ secrets.GITHUB_TOKEN }}
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
After recent changes to CI, it seems that the deploy workflow causes mixed permissions. Sidestep that protection by marking the mounted directory as a git safe directory.