### PR TITLE
Deploy workflow checkout with full depth

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Important for the committers plugin
       - name: Cache plugin data
         id: cache-plugins
         uses: actions/cache@v4


### PR DESCRIPTION
By default the repo was getting checked out at a depth of 1 which means we do not have the full git history. This caused the git commiters plugin to see all files as being added and updated at the current timestamp. This caused the footer to render incorrectly and the cache to be ineffective. This PR solves both issues.