### PR TITLE
linux/concepts: fix a mistake on atomics return value

### DIFF
--- a/docs/linux/concepts/concurrency.md
+++ b/docs/linux/concepts/concurrency.md
@@ -22,10 +22,10 @@ Since this happens in multiple steps, even such a simple operation is subject to
 
 There is a class of CPU instructions that can perform specific tasks in a single CPU instruction which is serialized at the hardware level. These are also available in BPF. When compiling with Clang/LLVM these special instructions can be accessed via a list of special builtin functions:
 
-* `__sync_fetch_and_add(*a, b)` - Read value at `a`, add `b` and write it back, return the new value
-* `__sync_fetch_and_sub(*a, b)` - Read value at `a`, subtract a number and write it back, return the new value
-* `__sync_fetch_and_or(*a, b)` - Read value at `a`, binary OR a number and write it back, return the new value
-* `__sync_fetch_and_xor(*a, b)` - Read value at `a`, binary XOR a number and write it back, return the new value
+* `__sync_fetch_and_add(*a, b)` - Read value at `a`, add `b` and write it back, return the original value of `a`
+* `__sync_fetch_and_sub(*a, b)` - Read value at `a`, subtract a number and write it back, return the original value of `a`
+* `__sync_fetch_and_or(*a, b)` - Read value at `a`, binary OR a number and write it back, return the original value of `a`
+* `__sync_fetch_and_xor(*a, b)` - Read value at `a`, binary XOR a number and write it back, return the original value of `a`
 * `__sync_val_compare_and_swap(*a, b, c)` - Read value at `a`, check if it is equal to `b`, if true write `c` to `a` and return the original value of `a`. On fail leave `a` be and return `c`.
 * `__sync_lock_test_and_set(*a, b)` - Read value at `a`, write `b` to `a`, return original value of `a`
 


### PR DESCRIPTION
See more details in the specification[^0]:
> The BPF_FETCH modifier is optional for simple atomic operations, and
always set for the complex atomic operations. If the BPF_FETCH flag is set, then the operation also overwrites src with the value that was in memory before it was modified.

Note that we could be even more explicit like they do with something like: "value that was in memory before it was modified".

[^0]: https://www.kernel.org/doc/html/v6.5/bpf/instruction-set.html#atomic-operations