### PR TITLE
Improve BPF_PROG_TYPE_SCHED_CLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .vscode/
-venv/** 
+.venv/** 

--- a/data/feature-versions.yaml
+++ b/data/feature-versions.yaml
@@ -332,6 +332,18 @@
     - name: BPF_LSM_CGROUP
       version: v6.0
       commit: 69fd337a975c7e690dfe49d9cb4fe5ba1e6db44e
+    - name: BPF_TCX_INGRESS
+      version: v6.6
+      commit: e420bed025071a623d2720a92bc2245c84757ecb
+    - name: BPF_TCX_EGRESS
+      version: v6.6
+      commit: e420bed025071a623d2720a92bc2245c84757ecb
+    - name: BPF_NETKIT_PRIMARY
+      version: v6.7
+      commit: 35dfaad7188cdc043fde31709c796f5a692ba2bd
+    - name: BPF_NETKIT_PEER
+      version: v6.7
+      commit: 35dfaad7188cdc043fde31709c796f5a692ba2bd
 - name: syscall_commands
   features:
     - name: BPF_MAP_CREATE

--- a/docs/linux/program-type/BPF_PROG_TYPE_SCHED_CLS.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_SCHED_CLS.md
@@ -102,27 +102,17 @@ For more details on the `tc` command, see the general [man page](https://man7.or
 For more details on the bpf filter options, see the `tc-bpf` [man page](https://man7.org/linux/man-pages/man8/tc-bpf.8.html).
 
 In addition, the kernel supports the tcx (the new tc BPF fast path with BPF link support) since kernel v6.6, which allows for more advanced features like attaching multiple programs to a single qdisc, or attaching programs to a qdisc on the egress side:
-```
-+-------------------------------------------+----------------------------------------+----------------------------------+-----------+
-| Program Type                              | Attach Type                            | ELF Section Name                 | Sleepable |
-+===========================================+========================================+==================================+===========+
-| ``BPF_PROG_TYPE_SCHED_CLS``               |                                        | ``classifier`` [#tc_legacy]_     |           |
-+                                           +                                        +----------------------------------+-----------+
-|                                           |                                        | ``tc`` [#tc_legacy]_             |           |
-+                                           +----------------------------------------+----------------------------------+-----------+
-|                                           | ``BPF_NETKIT_PRIMARY``                 | ``netkit/primary``               |           |
-+                                           +----------------------------------------+----------------------------------+-----------+
-|                                           | ``BPF_NETKIT_PEER``                    | ``netkit/peer``                  |           |
-+                                           +----------------------------------------+----------------------------------+-----------+
-|                                           | ``BPF_TCX_INGRESS``                    | ``tc/ingress``                   |           |
-+                                           +----------------------------------------+----------------------------------+-----------+
-|                                           | ``BPF_TCX_EGRESS``                     | ``tc/egress``                    |           |
-+                                           +----------------------------------------+----------------------------------+-----------+
-|                                           | ``BPF_TCX_INGRESS``                    | ``tcx/ingress``                  |           |
-+                                           +----------------------------------------+----------------------------------+-----------+
-|                                           | ``BPF_TCX_EGRESS``                     | ``tcx/egress``                   |           |
-+-------------------------------------------+----------------------------------------+----------------------------------+-----------+
-```
+
+
+| Attach Type          | ELF Section Name     |
+|----------------------|----------------------|
+`BPF_NETKIT_PRIMARY` | `netkit/primary`     |
+`BPF_NETKIT_PEER`    | `netkit/peer`        |
+`BPF_TCX_INGRESS`    | `tc/ingress`         |
+`BPF_TCX_EGRESS`     | `tc/egress`          |
+`BPF_TCX_INGRESS`    | `tcx/ingress`        |
+`BPF_TCX_EGRESS`     | `tcx/egress`         |
+
 
 The definition of return codes for tcx programs  can be found in the kernel sources:
 ```c

--- a/docs/linux/syscall/BPF_LINK_CREATE.md
+++ b/docs/linux/syscall/BPF_LINK_CREATE.md
@@ -522,6 +522,34 @@ The attach type is often used to communicate a specialization for a program type
 [:octicons-tag-24: v6.0](https://github.com/torvalds/linux/commit/69fd337a975c7e690dfe49d9cb4fe5ba1e6db44e)
 <!-- [/FEATURE_TAG] -->
 
+### `BPF_TCX_INGRESS`
+
+<!-- [FEATURE_TAG](BPF_TCX_INGRESS) -->
+[:octicons-tag-24: v6.6](https://github.com/torvalds/linux/commit/e420bed025071a623d2720a92bc2245c84757ecb)
+<!-- [/FEATURE_TAG] -->
+
+
+### `BPF_TCX_EGRESS`
+
+<!-- [FEATURE_TAG](BPF_TCX_EGRESS) -->
+[:octicons-tag-24: v6.6](https://github.com/torvalds/linux/commit/e420bed025071a623d2720a92bc2245c84757ecb)
+<!-- [/FEATURE_TAG] -->
+
+
+### `BPF_NETKIT_PRIMARY`
+
+<!-- [FEATURE_TAG](BPF_NETKIT_PRIMARY) -->
+[:octicons-tag-24: v6.7](https://github.com/torvalds/linux/commit/35dfaad7188cdc043fde31709c796f5a692ba2bd)
+<!-- [/FEATURE_TAG] -->
+
+
+### `BPF_NETKIT_PEER`
+
+<!-- [FEATURE_TAG](BPF_NETKIT_PEER) -->
+[:octicons-tag-24: v6.7](https://github.com/torvalds/linux/commit/35dfaad7188cdc043fde31709c796f5a692ba2bd)
+<!-- [/FEATURE_TAG] -->
+
+
 
 ## Flags
 

--- a/docs/linux/timeline/index.md
+++ b/docs/linux/timeline/index.md
@@ -787,10 +787,14 @@ hide: toc
 
 ## :octicons-tag-24: v6.6
 
+* `BPF_TCX_INGRESS` [e420bed](https://github.com/torvalds/linux/commit/e420bed025071a623d2720a92bc2245c84757ecb) (attach_types)
+* `BPF_TCX_EGRESS` [e420bed](https://github.com/torvalds/linux/commit/e420bed025071a623d2720a92bc2245c84757ecb) (attach_types)
 * `bpf_map_sum_elem_count` [803370d](https://github.com/torvalds/linux/commit/803370d3d37579e080e8c59f2360a072d0e45aff) (kfuncs)
 
 ## :octicons-tag-24: v6.7
 
+* `BPF_NETKIT_PRIMARY` [35dfaad](https://github.com/torvalds/linux/commit/35dfaad7188cdc043fde31709c796f5a692ba2bd) (attach_types)
+* `BPF_NETKIT_PEER` [35dfaad](https://github.com/torvalds/linux/commit/35dfaad7188cdc043fde31709c796f5a692ba2bd) (attach_types)
 * `bpf_percpu_obj_new_impl` [36d8bdf](https://github.com/torvalds/linux/commit/36d8bdf75a93190e5669b9d1d95994e13e15ba1d) (kfuncs)
 * `bpf_percpu_obj_drop_impl` [36d8bdf](https://github.com/torvalds/linux/commit/36d8bdf75a93190e5669b9d1d95994e13e15ba1d) (kfuncs)
 * `bpf_throw` [fd5d27b](https://github.com/torvalds/linux/commit/fd5d27b70188379bb441d404c29a0afb111e1753) (kfuncs)


### PR DESCRIPTION
The table of attach types in the BPF_PROG_TYPE_SCHED_CLS.md page was not parsed and a bit messy, I therefore simplified it to only keep the currently supported attach types. I included these new attach types in the feature versions tracking file.