### PR TITLE
Fix metadata on struct_ops pages

### DIFF
--- a/docs/linux/program-type/BPF_PROG_TYPE_STRUCT_OPS/hid_bpf_ops.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_STRUCT_OPS/hid_bpf_ops.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'hid_bpf_ops'"
+title: "Struct ops 'hid_bpf_ops'"
 description: "This page documents the 'hid_bpf_ops' struct ops, its semantics, capabilities, and limitations."
 ---
 # Struct ops `hid_bpf_ops`

--- a/docs/linux/program-type/BPF_PROG_TYPE_STRUCT_OPS/sched_ext_ops.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_STRUCT_OPS/sched_ext_ops.md
@@ -1,6 +1,6 @@
 ---
-title: "Program Type 'tcp_congestion_ops'"
-description: "This page documents the 'tcp_congestion_ops' struct ops, its semantics, capabilities, and limitations."
+title: "Struct ops 'sched_ext_ops'"
+description: "This page documents the 'sched_ext_ops' struct ops, its semantics, capabilities, and limitations."
 ---
 # Struct ops `sched_ext_ops`
 

--- a/docs/linux/program-type/BPF_PROG_TYPE_STRUCT_OPS/tcp_congestion_ops.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_STRUCT_OPS/tcp_congestion_ops.md
@@ -1,5 +1,5 @@
 ---
-title: "Program Type 'tcp_congestion_ops'"
+title: "Struct ops 'tcp_congestion_ops'"
 description: "This page documents the 'tcp_congestion_ops' struct ops, its semantics, capabilities, and limitations."
 ---
 # Struct ops `tcp_congestion_ops`


### PR DESCRIPTION
The metadata on the struct_ops pages was incorrect, due to a copy paste mistake.