### PR TITLE
concepts/trampolines.md: Improve trampoline explanation

### DIFF
--- a/docs/linux/concepts/trampolines.md
+++ b/docs/linux/concepts/trampolines.md
@@ -6,7 +6,50 @@ Trampolines in computing has a number of meanings. In the context of Linux this 
 
 [:octicons-tag-24: v2.6.27](https://github.com/torvalds/linux/commit/16444a8a40d4c7b4f6de34af0cae1f76a4f6c901)
 
-Ftrace (function trace) is a mechanism in the kernel for observing function execution, traditionally for debugging purposes. Ftrace also uses trampolines, but in a slightly different way. It is enabled when compiled with the `CONFIG_FUNCTION_TRACER` kernel configuration. When enabled, most files in the kernel are compiled with the `-pg` and `-mnop-mcount=...` flags. The `-pg` flag enables profiling, which adds some additional CPU instructions to the start of most global functions. The `-mnop-mcount=...` flag makes it so these CPU instructions are [`NOP` (No Operation)](https://en.wikipedia.org/wiki/NOP_(code)) instructions as apposed to the normal profiling logic. So by default, when a function is called, the CPU encounters a few `NOP` instructions which it will ignore and then continue the actual function. However, at runtime the kernel can replace these `NOP` instructions with a trampoline to in the case of ftrace some tracing logic.
+Ftrace (function trace) is a mechanism in the kernel for observing function execution, traditionally for debugging purposes. Ftrace also uses trampolines, but in a slightly different way. It is enabled when compiled with the `CONFIG_FUNCTION_TRACER` kernel configuration. When enabled, most files in the kernel are compiled with the `-pg` and `-mnop-mcount=...` flags. The `-pg` flag enables profiling, which adds some additional CPU instructions to the start of most global functions. The `-mnop-mcount=...` flag makes it so these CPU instructions are [`NOP` (No Operation)](https://en.wikipedia.org/wiki/NOP_(code)) instructions as apposed to the normal profiling logic. 
+
+So by default, when a function is called, the CPU encounters a few `NOP` instructions which it will ignore and then continue the actual function. However, at runtime the kernel can replace these `NOP` instructions with a trampoline to in the case of ftrace some tracing logic.
+
+Without `CONFIG_FUNCTION_TRACER`, the the assembly code for a function might look like this:
+
+```
+some_kernel_func:
+  PUSH RBP
+  MOV RSP, RBP
+  ...
+  RET
+```
+
+With `CONFIG_FUNCTION_TRACER` but without any tracing enabled, the assembly code for a function might look like this:
+```
+# Symbol where instructions like: CALL some_kernel_func will jump to.
+some_kernel_func:
+  NOP
+  NOP
+# actual start of the function
+  PUSH RBP
+  MOV RSP, RBP
+  ...
+  RET
+```
+
+The `NOP` instructions are ignored by the CPU as if they were not there.
+ 
+Then at runtime, the kernel can replace the `NOP` instructions with code that adds the tracing. For example, the assembly code for a function with tracing enabled might look like this:
+
+```
+# Symbol where instructions like: CALL some_kernel_func will jump to.
+some_kernel_func:
+  CALL trace_call
+  NOP
+# actual start of the function
+  PUSH RBP
+  MOV RSP, RBP
+  [...]
+  RET
+```
+
+In this case the `trace_call` function would implement the actual tracing logic. The second `NOP` is here to illustrate that code of different sizes can be patched into the room left by the `NOP` instructions.
 
 It should be noted that certain directories, files or functions in the kernel are excluded. For example the trace subsystem (kernel/trace) is excluded and any functions with the `notrace` attribute. This is done to protect the user from infinite recursion or breaking assumptions in critical code sections of the kernel.
 
@@ -14,28 +57,44 @@ It should be noted that certain directories, files or functions in the kernel ar
 
 [:octicons-tag-24: v5.5](https://github.com/torvalds/linux/commit/fec56f5890d93fc2ed74166c397dc186b1c25951)
 
-BPF programs can be attached to any function in the kernel that has enough `NOP` instructions. When this is done, a "BPF trampoline" is created. This is a architecture specific function that boils down to:
+BPF programs can be attached to any function in the kernel that has enough `NOP` instructions. When this is done, a "BPF trampoline" is created. Somewhat confusing since normally the section of `NOP` instructions is called a trampoline, but in this case when we talk about a "BPF trampoline" we are talking about the code we jump to from a trampoline.
+
+When a BPF program is attached, the kernel patches the `NOP` instruction on the original function like so:
+
+```
+# Symbol where instructions like: CALL some_kernel_func will jump to.
+some_kernel_func:
+  CALL generated_bpf_trampoline
+  RET
+# actual start of the function
+  PUSH RBP
+  MOV RSP, RBP
+  [...]
+  RET
+```
+
+This does not just add some additional logic like when tracing, it effectively redirects the execution of the original function to the generated BPF trampoline. The trampoline can now chose to never call the original (the `freplace` use case), call a BPF program before the original (the `fentry` use case), after the original (the `fexit` use case) or modify the return value of the original (the `fmodify_return` use case). It is also this generated trampoline that allows multiple programs to co-exist on the same function.
+
+The generated BPF trampoline is architecture specific dynamically generated machine code that boils down to:
 
 * Allocate room on the stack for all function arguments + return value
 * Copy all arguments to the stack, from the registers specified by the calling convention
-* For each fentry program attached
-    * Call the fentry program with a pointer to the stack as context (if any is attached)
+* For each `fentry` program attached
+    * Call the `fentry` program with a pointer to the stack as context (if any is attached)
         * Disable CPU migration (preemption on older kernels) before calling the program, re-enable after
         * If stats tracking is enabled, start timer before execution and add run time to stats after execution
-* For each fmodify_return program attached
-    * Call a fmodify_return program with a pointer to the stack as context (if any is attached)
+* For each `fmodify_return` program attached
+    * Call a `fmodify_return` program with a pointer to the stack as context (if any is attached)
         * Disable CPU migration (preemption on older kernels) before calling the program, re-enable after
         * If stats tracking is enabled, start timer before execution and add run time to stats after execution
         * If the return value is non zero, return it instead of continuing
-* Call the original function (unless a fmodify_return program returned a non `0` value)
+* Call the original function (unless a `fmodify_return` program returned a non `0` value)
 * Copy return value from register onto the stack
-* For each fexit program attached
-    * Call a fexit program with a pointer to the stack as context (if any is attached)
+* For each `fexit` program attached
+    * Call a `fexit` program with a pointer to the stack as context (if any is attached)
         * Disable CPU migration (preemption on older kernels) before calling the program, re-enable after
         * If stats tracking is enabled, start timer before execution and add run time to stats after execution
 * Return the return value from the stack
-
-The `NOP`s are replaced with a call to the generated trampoline and a return instruction.
 
 ### Architecture support
 
@@ -68,4 +127,4 @@ Trampolines are also used to implement [freplace programs](../program-type/BPF_P
 
 [:octicons-tag-24: v5.7](https://github.com/torvalds/linux/commit/9e4e01dfd3254c7f04f24b7c6b29596bc12332f3)
 
-[LSM](../program-type/BPF_PROG_TYPE_LSM.md) programs also attach via trampolines very similar to fexit/fret_mod programs. The kernel defines placeholder functions for every hook, always starting with the prefix `bpf_lsm_`. These placeholders simply return the default return value. When attached, the LSM program acts as fexit or fret_mod probe for the purposes of the BPF trampoline on these placeholder hooks.
+[LSM](../program-type/BPF_PROG_TYPE_LSM.md) programs also attach via trampolines very similar to `fexit`/`fmodify_return` programs. The kernel defines placeholder functions for every hook, always starting with the prefix `bpf_lsm_`. These placeholders simply return the default return value. When attached, the LSM program acts as `fexit` or `fmodify_return` probe for the purposes of the BPF trampoline on these placeholder hooks.


### PR DESCRIPTION
This commit adds a little bit more explanation around the usage of `NOP` instructions, including some pseudo-assembly to explain the concept better.

Fixes: #113