### PR TITLE
linux/syscall: add missing text to BPF_MAP_LOOKUP_BATCH

### DIFF
--- a/docs/linux/syscall/BPF_MAP_LOOKUP_BATCH.md
+++ b/docs/linux/syscall/BPF_MAP_LOOKUP_BATCH.md
@@ -28,7 +28,7 @@ This attribute is set by userspace. At the start of iteration it should be set t
 
 ### `out_batch`
 
-This attribute is set by the kernel during the command execution. At the start of iteration it should be set to `0`/`NULL`. The kernel will 
+This attribute is set by the kernel during the command execution. At the start of iteration it should be set to `0`/`NULL`. The kernel will write the pointer to the key for the next batch start to this field. The value is opaque, the kernel has internally assigned meaning, but userspace should just copy the values without modification.
 
 ### `keys`
 


### PR DESCRIPTION
The last line in the `out_batch` section is missing some text. I just added some, but feel free to edit my commit or replace it entirely with your own fix. 