### PR TITLE
docs/linux: add missing feature tags for map/program types

### DIFF
--- a/docs/linux/map-type/BPF_MAP_TYPE_CGROUP_ARRAY.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_CGROUP_ARRAY.md
@@ -4,5 +4,9 @@ description: "This page documents the 'BPF_MAP_TYPE_CGROUP_ARRAY' eBPF map type,
 ---
 # Map type `BPF_MAP_TYPE_CGROUP_ARRAY`
 
+<!-- [FEATURE_TAG](BPF_MAP_TYPE_CGROUP_ARRAY) -->
+[:octicons-tag-24: v4.8](https://github.com/torvalds/linux/commit/4ed8ec521ed57c4e207ad464ca0388776de74d4b)
+<!-- [/FEATURE_TAG] -->
+
 !!! example "Docs could be improved"
     This part of the docs is incomplete, contributions are very welcome

--- a/docs/linux/map-type/BPF_MAP_TYPE_HASH_OF_MAPS.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_HASH_OF_MAPS.md
@@ -4,5 +4,9 @@ description: "This page documents the 'BPF_MAP_TYPE_HASH_OF_MAPS' eBPF map type,
 ---
 # Map type `BPF_MAP_TYPE_HASH_OF_MAPS`
 
+<!-- [FEATURE_TAG](BPF_MAP_TYPE_HASH_OF_MAPS) -->
+[:octicons-tag-24: v4.12](https://github.com/torvalds/linux/commit/bcc6b1b7ebf857a9fe56202e2be3361131588c15)
+<!-- [/FEATURE_TAG] -->
+
 !!! example "Docs could be improved"
     This part of the docs is incomplete, contributions are very welcome

--- a/docs/linux/map-type/BPF_MAP_TYPE_LRU_PERCPU_HASH.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_LRU_PERCPU_HASH.md
@@ -4,5 +4,9 @@ description: "This page documents the 'BPF_MAP_TYPE_LRU_PERCPU_HASH' eBPF map ty
 ---
 # Map type `BPF_MAP_TYPE_LRU_PERCPU_HASH`
 
+<!-- [FEATURE_TAG](BPF_MAP_TYPE_LRU_PERCPU_HASH) -->
+[:octicons-tag-24: v4.10](https://github.com/torvalds/linux/commit/8f8449384ec364ba2a654f11f94e754e4ff719e0)
+<!-- [/FEATURE_TAG] -->
+
 !!! example "Docs could be improved"
     This part of the docs is incomplete, contributions are very welcome

--- a/docs/linux/map-type/BPF_MAP_TYPE_USER_RINGBUF.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_USER_RINGBUF.md
@@ -4,5 +4,9 @@ description: "This page documents the 'BPF_MAP_TYPE_USER_RINGBUF' eBPF map type,
 ---
 # Map type `BPF_MAP_TYPE_USER_RINGBUF`
 
+<!-- [FEATURE_TAG](BPF_MAP_TYPE_USER_RINGBUF) -->
+[:octicons-tag-24: v6.1](https://github.com/torvalds/linux/commit/583c1f420173f7d84413a1a1fbf5109d798b4faa)
+<!-- [/FEATURE_TAG] -->
+
 !!! example "Docs could be improved"
     This part of the docs is incomplete, contributions are very welcome

--- a/docs/linux/program-type/BPF_PROG_TYPE_LIRC_MODE2.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_LIRC_MODE2.md
@@ -4,5 +4,9 @@ description: "This page documents the 'BPF_PROG_TYPE_LIRC_MODE2' eBPF program ty
 ---
 # Program type `BPF_PROG_TYPE_LIRC_MODE2`
 
+<!-- [FEATURE_TAG](BPF_PROG_TYPE_LIRC_MODE2) -->
+[:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/f4364dcfc86df7c1ca47b256eaf6b6d0cdd0d936)
+<!-- [/FEATURE_TAG] -->
+
 !!! example "Docs could be improved"
     This part of the docs is incomplete, contributions are very welcome

--- a/docs/linux/program-type/BPF_PROG_TYPE_LWT_SEG6LOCAL.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_LWT_SEG6LOCAL.md
@@ -4,5 +4,9 @@ description: "This page documents the 'BPF_PROG_TYPE_LWT_SEG6LOCAL' eBPF program
 ---
 # Program type `BPF_PROG_TYPE_LWT_SEG6LOCAL`
 
+<!-- [FEATURE_TAG](BPF_PROG_TYPE_LWT_SEG6LOCAL) -->
+[:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/004d4b274e2a1a895a0e5dc66158b90a7d463d44)
+<!-- [/FEATURE_TAG] -->
+
 !!! example "Docs could be improved"
     This part of the docs is incomplete, contributions are very welcome


### PR DESCRIPTION
While the documentation page for these map/program types is still empty, at least document the kernel version/commit they were added in so provide some initial context.