### PR TITLE
Add the usage and example part to the helper function bpf_probe_read_kernel_str

### DIFF
--- a/docs/linux/helper-function/bpf_probe_read_kernel_str.md
+++ b/docs/linux/helper-function/bpf_probe_read_kernel_str.md
@@ -25,8 +25,9 @@ On success, the strictly positive length of the string, including the trailing N
 
 ## Usage
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+The `dst` argument must be a pointer to a buffer where the null-terminated string will be copied. The `size` argument specifies the maximum number of bytes to copy, including the null terminator. The `unsafe_ptr` argument must be a pointer located in kernel memory.
+
+The return value is the number of bytes copied, including the null terminator, or a negative error code if the memory is inaccessible. This function ensures the copied string is null-terminated. If the string is **shorter than** `size`, the buffer is **not padded** with extra null bytes. If the string is **longer than** `size - 1`, only `size - 1` bytes are copied, and the last byte is set to null.
 
 ### Program types
 
@@ -68,5 +69,25 @@ This helper call can be used in the following program types:
 
 ### Example
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+```c
+
+SEC("tracepoint/syscalls/sys_exit_openat")
+int trace_open(struct trace_event_raw_sys_exit *ctx) {
+    char comm[256];
+    struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+    
+    // Try to read the process name and check for errors
+    int ret = bpf_probe_read_kernel_str(comm, sizeof(comm), task->comm);
+    
+    if (ret < 0) {
+        bpf_printk("Failed to read process name, error: %d\n", ret);
+        return 0;
+    }
+
+    bpf_printk("Process name: %s\n", comm);
+    
+    return 0;
+}
+
+
+```


### PR DESCRIPTION
This PR adds a detailed usage explanation and example for the helper function `bpf_probe_read_kernel_str`. The update improves the documentation by providing a clear demonstration of how to use the function.

# Changes

## Changes in Usage Section
**Previous documentation:**
![imagen_2025-03-25_135321743](https://github.com/user-attachments/assets/1f174028-3a86-4d37-b61a-b565957968d7)
**Updated documentation:**
![imagen_2025-03-25_135433101](https://github.com/user-attachments/assets/e3bc21d1-e4a6-475f-a04c-1f647c9a69c5)

## Changes in Example Section

**Previous documentation:**
![image](https://github.com/user-attachments/assets/fcdeb4e1-d0a0-4c6f-a2ce-ec04bcd4bfa8)

**Updated documentation:**

![imagen_2025-03-25_135538537](https://github.com/user-attachments/assets/f445dfec-bd09-4fc2-b7c9-d222952ee9e4)

# Why This Change?

- Helps new users understand how to use `bpf_probe_read_kernel_str` effectively.

## Additional Notes
This is my first contribution to eBPF documentation, so feedback is highly appreciated! If any improvements are needed, I’m happy to adjust accordingly. 