### PR TITLE
linux/syscall: Update create and load syscall pages

### DIFF
--- a/docs/linux/program-type/BPF_PROG_TYPE_PERF_EVENT.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_PERF_EVENT.md
@@ -86,7 +86,7 @@ This is the newest and most recommended method of attaching perf event programs.
 
 After we have gotten the perf event file descriptor we attach the program by making a bpf link via the [link create syscall command](../syscall/BPF_LINK_CREATE.md).
 
-We call the syscall command with the [`BPF_PERF_EVENT`](../syscall/BPF_LINK_CREATE.md#bpf_perf_event) [`attach_type`](../syscall/BPF_LINK_CREATE.md#attach_type), [`target_fd`](../syscall/BPF_LINK_CREATE.md#target_fd) set to the perf event file descriptor, [`prog_fd`](../syscall/BPF_LINK_CREATE.md#prog_fd) to the file descriptor of the tracepoint program, and optionally a [`cookie`](../syscall/BPF_LINK_CREATE.md#cookie)
+We call the syscall command with the [`BPF_PERF_EVENT`](../syscall/BPF_LINK_CREATE.md#bpf_perf_event) [`attach_type`](../syscall/BPF_LINK_CREATE.md#attach_type), [`target_fd`](../syscall/BPF_LINK_CREATE.md#target_fd) set to the perf event file descriptor, [`prog_fd`](../syscall/BPF_LINK_CREATE.md#prog_fd) to the file descriptor of the tracepoint program, and optionally a [`cookie`](../syscall/BPF_LINK_CREATE.md#tracing-cookie)
 
 
 ## Examples

--- a/docs/linux/program-type/BPF_PROG_TYPE_TRACEPOINT.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_TRACEPOINT.md
@@ -104,7 +104,7 @@ This is the newest and most recommended method of attaching tracepoint programs.
 
 After we have gotten the perf event file descriptor we attach the program by making a bpf link via the [link create syscall command](../syscall/BPF_LINK_CREATE.md).
 
-We call the syscall command with the [`BPF_PERF_EVENT`](../syscall/BPF_LINK_CREATE.md#bpf_perf_event) [`attach_type`](../syscall/BPF_LINK_CREATE.md#attach_type), [`target_fd`](../syscall/BPF_LINK_CREATE.md#target_fd) set to the perf event file descriptor, [`prog_fd`](../syscall/BPF_LINK_CREATE.md#prog_fd) to the file descriptor of the tracepoint program, and optionally a [`cookie`](../syscall/BPF_LINK_CREATE.md#cookie)
+We call the syscall command with the [`BPF_PERF_EVENT`](../syscall/BPF_LINK_CREATE.md#bpf_perf_event) [`attach_type`](../syscall/BPF_LINK_CREATE.md#attach_type), [`target_fd`](../syscall/BPF_LINK_CREATE.md#target_fd) set to the perf event file descriptor, [`prog_fd`](../syscall/BPF_LINK_CREATE.md#prog_fd) to the file descriptor of the tracepoint program, and optionally a [`cookie`](../syscall/BPF_LINK_CREATE.md#tracing-cookie)
 
 ## Helper functions
 

--- a/docs/linux/syscall/BPF_BTF_LOAD.md
+++ b/docs/linux/syscall/BPF_BTF_LOAD.md
@@ -16,6 +16,21 @@ This command will return a file descriptor to the created BTF object on success 
 
 ## Attributes
 
+```c
+union bpf_attr {
+    struct {
+		__aligned_u64   [btf](#btf);
+		__aligned_u64   [btf_log_buf](#btf_log_buf);
+		__u32           [btf_size](#btf_size);
+		__u32           [btf_log_size](#btf_log_size);
+		__u32           [btf_log_level](#btf_log_level);
+		__u32           [btf_log_true_size](#btf_log_true_size);
+		__u32           [btf_flags](#btf_flags);
+		__s32           [btf_token_fd](#btf_token_fd);
+	};
+};
+```
+
 ### `btf`
 
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/f56a653c1fd13a197076dec4461c656fd2adec73)
@@ -44,10 +59,34 @@ This field is the size of the memory region indicated by `btf_log_buf`
 
 [:octicons-tag-24: v4.18](https://github.com/torvalds/linux/commit/f56a653c1fd13a197076dec4461c656fd2adec73)
 
-This field is the level of detail contained in the log. Possible values are:
+The lower 2 bits of this value are the log level:
 
 * `0` = no log
 * `1` = basic logging   (`BPF_LOG_LEVEL1`)
 * `2` = verbose logging (`BPF_LOG_LEVEL2`)
 
-Additionally the 3rd bit is a flag, if set the kernel will output statistics to the log (`BPF_LOG_STATS`).
+The remaining bits are flags:
+
+* `1 << 3` (`BPF_LOG_STATS`) If set the kernel will output statistics to the log. Flags can be used since [:octicons-tag-24: v5.2](https://github.com/torvalds/linux/commit/06ee7115b0d1742de745ad143fb5e06d77d27fba)
+
+* `1 << 4` (`BPF_LOG_FIXED`) since [:octicons-tag-24: v6.4](https://github.com/torvalds/linux/commit/1216640938035e63bdbd32438e91c9bcc1fd8ee1), the verifier log rotates instead of truncating. When `log_size` is exceeded. Setting this flag preserves the old behavior of truncating the log to `log_size` bytes.
+
+### `btf_flags`
+
+[:octicons-tag-24: v6.9](https://github.com/torvalds/linux/commit/9ea7c4bf17e39d463eb4782f948f401d9764b1b3)
+
+This field is a bitmask of flags that control the behavior of the BTF loading process. See the [Flags](#flags) section for more information.
+
+### `btf_token_fd`
+
+[:octicons-tag-24: v6.9](https://github.com/torvalds/linux/commit/9ea7c4bf17e39d463eb4782f948f401d9764b1b3)
+
+The file descriptor of a [BPF token](../../linux/concepts/token.md) can be passed to this attribute. If the BPF token grants permission to create a BTF object, the kernel will allow the program to be loaded for a user without `CAP_BPF`.
+
+## Flags
+
+### `BPF_F_TOKEN_FD`
+
+[:octicons-tag-24: v6.9](https://github.com/torvalds/linux/commit/9ea7c4bf17e39d463eb4782f948f401d9764b1b3)
+
+This flag indicates that the [`btf_token_fd`](#btf_token_fd) attribute is being used. If this flag is not set, the kernel will ignore the [`btf_token_fd`](#btf_token_fd) attribute.

--- a/docs/linux/syscall/BPF_MAP_CREATE.md
+++ b/docs/linux/syscall/BPF_MAP_CREATE.md
@@ -16,11 +16,38 @@ This command will return a file descriptor to the created map on success (positi
 
 ## Attributes
 
+```c
+union bpf_attr {
+    struct {
+		__u32	[map_type](#map_type);
+		__u32	[key_size](#key_size);
+		__u32	[value_size](#value_size);
+		__u32	[max_entries](#max_entries);
+		__u32	[map_flags](#map_flags);
+		__u32	[inner_map_fd](#inner_map_fd);
+		__u32	[numa_node](#numa_node);
+		char	[map_name](#map_name)[BPF_OBJ_NAME_LEN];
+		__u32	[map_ifindex](#map_ifindex);
+		__u32	[btf_fd](#btf_fd);
+		__u32	[btf_key_type_id](#btf_key_type_id);
+		__u32	[btf_value_type_id](#btf_value_type_id);
+		__u32	[btf_vmlinux_value_type_id](#btf_vmlinux_value_type_id);
+		__u64	[map_extra](#map_extra);
+		__s32   [value_type_btf_obj_fd](#value_type_btf_obj_fd);	
+		__s32	[map_token_fd](#map_token_fd);
+	};
+};
+```
+
 ### `map_type`
+
+[:octicons-tag-24: v3.18](https://github.com/torvalds/linux/commit/99c55f7d47c0dc6fc64729f37bf435abf43f4c60)
 
 This attribute specifies which type of map should be created, this should be one of the pre-defined [map types](../map-type/index.md).
 
 ### `key_size`
+
+[:octicons-tag-24: v3.18](https://github.com/torvalds/linux/commit/99c55f7d47c0dc6fc64729f37bf435abf43f4c60)
 
 This attribute specifies the size of the key in bytes. 
 
@@ -29,12 +56,16 @@ This attribute specifies the size of the key in bytes.
 
 ### `value_size`
 
+[:octicons-tag-24: v3.18](https://github.com/torvalds/linux/commit/99c55f7d47c0dc6fc64729f37bf435abf43f4c60)
+
 This attribute specifies the size of the value in bytes. 
 
 !!! info
     Some map types have restrictions on which values are allowed, check the documentation of the specific map type for more details.
 
 ### `max_entries`
+
+[:octicons-tag-24: v3.18](https://github.com/torvalds/linux/commit/99c55f7d47c0dc6fc64729f37bf435abf43f4c60)
 
 This attribute specifies the maximum amount of entries the map can hold.
 
@@ -43,9 +74,12 @@ This attribute specifies the maximum amount of entries the map can hold.
 
 ### `map_flags`
 
+[:octicons-tag-24: v4.6](https://github.com/torvalds/linux/commit/6c90598174322b8888029e40dd84a4eb01f56afe)
+
 This attribute is a bitmask of flags, see the [flags](#flags) section below for details.
 
 ### `inner_map_fd`
+
 [:octicons-tag-24: v4.12](https://github.com/torvalds/linux/commit/56f668dfe00dcf086734f1c42ea999398fad6572)
 
 This attribute should be set to the FD of another map when creating [map-in-map](../map-type/index.md#map-in-map) type maps. Doing so doesn't link the specified inner map to this new map we are creating, rather it is used as a mechanism to inform the kernel of the inner-maps attributes like type, key size, value size. When writing map references as values to this map, the kernel will verify that those maps are compatible with the attributes of the map given via this field.
@@ -116,8 +150,7 @@ This attribute is used when creating a [`BPF_MAP_TYPE_STRUCT_OPS`](../map-type/B
 
 ### `map_token_fd`
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+The file descriptor of a [BPF token](../../linux/concepts/token.md) can be passed to this attribute. If the BPF token grants permission to create a map of the type specified in [`map_type`](#map_type), the kernel will allow the map to be created for a user without `CAP_BPF`.
 
 ## Flags
 
@@ -131,16 +164,13 @@ Before kernel version v4.6, [`BPF_MAP_TYPE_HASH`](../map-type/BPF_MAP_TYPE_HASH.
 
 Some map types require the loader to set this flag when creating maps to explicitly make clear that memory for such map types is always lazily allocated (also to guarantee stable behavior in case pre-allocation for those maps is ever added).
 
-<!-- TODO list map types with support and link to specific pages -->
-
 ### `BPF_F_NO_COMMON_LRU`
 
 <!-- [FEATURE_TAG](BPF_F_NO_COMMON_LRU) -->
 [:octicons-tag-24: v4.10](https://github.com/torvalds/linux/commit/29ba732acbeece1e34c68483d1ec1f3720fa1bb3)
 <!-- [/FEATURE_TAG] -->
 
-By default, LRU maps have a single LRU list (even per-CPU LRU maps). When set, the an LRU map will use a per-CPU LRU list
-which can scale and perform better.
+By default, LRU maps have a single LRU (even per-CPU LRU maps). When set, a LRU map will use a per-CPU LRU which has better performance in certain cases, but also has implications. See [`BPF_MAP_TYPE_LRU_HASH`](../map-type/BPF_MAP_TYPE_LRU_HASH.md#lru-internals) for more details.
 
 !!! note
     The LRU nodes (including free nodes) cannot be moved across different LRU lists.
@@ -152,7 +182,6 @@ which can scale and perform better.
 <!-- [/FEATURE_TAG] -->
 
 When set, the [`numa_node`](#numa_node) attribute is respected during map creation.
-
 
 ### `BPF_F_RDONLY`
 
@@ -272,15 +301,6 @@ The `BPF_F_LINK` flag is used to indicate that a link is to be used to attach a 
 !!! note
     This flag has a different meaning when used in the `BPF_LINK_CREATE` command.
 
-### `BPF_F_PATH_FD`
-
-<!-- [FEATURE_TAG](BPF_F_PATH_FD) -->
-[:octicons-tag-24: v6.5](https://github.com/torvalds/linux/commit/cb8edce28073a906401c9e421eca7c99f3396da1)
-<!-- [/FEATURE_TAG] -->
-
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
-
 ### `BPF_F_VTYPE_BTF_OBJ_FD`
 
 <!-- [FEATURE_TAG](BPF_F_VTYPE_BTF_OBJ_FD) -->
@@ -295,8 +315,7 @@ The `BPF_F_VTYPE_BTF_OBJ_FD` flag is used to indicate that the [`btf_vmlinux_val
 [:octicons-tag-24: v6.9](https://github.com/torvalds/linux/commit/a177fc2bf6fd83704854feaf7aae926b1df4f0b9)
 <!-- [/FEATURE_TAG] -->
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+When set, the kernel will use the BPF token in [`map_token_fd`](#map_token_fd) to authorize the creation of the map instead of checking the capabilities of the current user.
 
 ### `BPF_F_SEGV_ON_FAULT`
 


### PR DESCRIPTION
Revisit the create / load syscall pages for the BPF objects. Updated added fields and flags. Also updated the C defintions and added links from the code to their respective sections.