### PR TITLE
docs(bpf_program__attach_uprobe_multi): remove typo in attach args

### DIFF
--- a/docs/ebpf-library/libbpf/userspace/bpf_program__attach_uprobe_multi.md
+++ b/docs/ebpf-library/libbpf/userspace/bpf_program__attach_uprobe_multi.md
@@ -84,7 +84,7 @@ Array of offsets to USDT reference counter fields. See:
 - [https://github.com/torvalds/linux/commit/1cc33161a83d](https://github.com/torvalds/linux/commit/1cc33161a83d)
 - [https://github.com/torvalds/linux/commit/a6ca88b241d5](https://github.com/torvalds/linux/commit/a6ca88b241d5)
 
-This field is optional, and can be `NULL` if you do not need to pass any cookies.
+This field is optional, and can be `NULL` if you do not need to pass any USDT reference counters.
 
 #### `session`
 


### PR DESCRIPTION
docs(userspace/bpf_program__attach_uprobe_multi): remove typo in attach function args

The ref_ctr_offsets argument to the bpf_program__attach_uprobe_multi
lbbpf function for attching multiple uprobes via multi link, wrongly
referenced the cookies