### PR TITLE
Add version tags to atomic operations

### DIFF
--- a/docs/linux/concepts/concurrency.md
+++ b/docs/linux/concepts/concurrency.md
@@ -24,10 +24,10 @@ There is a class of CPU instructions that can perform specific tasks in a single
 
 * `__sync_fetch_and_add(*a, b)` - Read value at `a`, add `b` and write it back, return the original value of `a`
 * `__sync_fetch_and_sub(*a, b)` - Read value at `a`, subtract a number and write it back, return the original value of `a`
-* `__sync_fetch_and_or(*a, b)` - Read value at `a`, binary OR a number and write it back, return the original value of `a`
-* `__sync_fetch_and_xor(*a, b)` - Read value at `a`, binary XOR a number and write it back, return the original value of `a`
-* `__sync_val_compare_and_swap(*a, b, c)` - Read value at `a`, check if it is equal to `b`, if true write `c` to `a` and return the original value of `a`. On fail leave `a` be and return `c`.
-* `__sync_lock_test_and_set(*a, b)` - Read value at `a`, write `b` to `a`, return original value of `a`
+* `__sync_fetch_and_or(*a, b)` - Read value at `a`, binary OR a number and write it back, return the original value of `a` :octicons-tag-24: [v5.12](https://lwn.net/ml/linux-kernel/20210114181751.768687-1-jackmanb@google.com/)
+* `__sync_fetch_and_xor(*a, b)` - Read value at `a`, binary XOR a number and write it back, return the original value of `a` :octicons-tag-24: [v5.12](https://lwn.net/ml/linux-kernel/20210114181751.768687-1-jackmanb@google.com/)
+* `__sync_val_compare_and_swap(*a, b, c)` - Read value at `a`, check if it is equal to `b`, if true write `c` to `a` and return the original value of `a`. On fail leave `a` be and return `c`. :octicons-tag-24: [v5.12](https://lwn.net/ml/linux-kernel/20210114181751.768687-1-jackmanb@google.com/)
+* `__sync_lock_test_and_set(*a, b)` - Read value at `a`, write `b` to `a`, return original value of `a` :octicons-tag-24: [v5.12](https://lwn.net/ml/linux-kernel/20210114181751.768687-1-jackmanb@google.com/)
 
 If you want to perform one of the above sequences on a variable you can do so with the atomic builtin functions. A common example is to increment a shared counter with `__sync_fetch_and_add`.
 


### PR DESCRIPTION
Support for atomic operations other than ADD were added only with Linux 5.12. The docs for concurrency have been extended with a version tag to make this explicit.