### PR TITLE
Fix grammar in libbpf component description

### DIFF
--- a/docs/ebpf-library/libbpf/index.md
+++ b/docs/ebpf-library/libbpf/index.md
@@ -7,7 +7,7 @@ hide: toc
 
 Libbpf is the reference library for eBPF development. It is developed and maintained as [part of the kernel tree](https://github.com/torvalds/linux/tree/master/tools/lib/bpf) often in lockstep with the kernel itself. Since including the whole kernel tree in a project is not practical, a mirror of just the libbpf library is maintained at [https://github.com/libbpf/libbpf](https://github.com/libbpf/libbpf).
 
-Libbpf has both userspace components and eBPF components. The eBPF components are mostly pre-processor statements, forward declarations and type definitions that make it easier to write eBPF programs. The userspace components is a library that for loading eBPF programs and interacting with the loaded resources.
+Libbpf has both userspace components and eBPF components. The eBPF components are mostly pre-processor statements, forward declarations, and type definitions that make it easier to write eBPF programs. The userspace components are a library used for loading eBPF programs and interacting with the loaded resources.
 
 <div class="grid cards" markdown>
 


### PR DESCRIPTION
This PR makes a small grammar fix in the libbpf component description. 

Another possible version could have been:
> The userspace component is a library used for loading eBPF programs and interacting with the loaded resources.