### PR TITLE
Add usage examples for helper functions

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -245,6 +245,7 @@ backend
 programmatically
 tc
 tcx
+TGID
 Netkit
 netkit
 sched

--- a/docs/linux/helper-function/bpf_get_current_cgroup_id.md
+++ b/docs/linux/helper-function/bpf_get_current_cgroup_id.md
@@ -25,8 +25,7 @@ A 64-bit integer containing the current cgroup id based on the cgroup within whi
 
 ## Usage
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+The `bpf_get_current_cgroup_id` helper function retrieves the cGroup ID of the cGroup in which the current task is running. This ID corresponds to the cGroup's file descriptor in the cGroup filesystem (`/sys/fs/cgroup`) and uniquely identifies a cGroup. It may be used to distinguish between containers, as container runtimes rely on cGroups for resource isolation and attribute a unique cGroup to each container. This helper function also enables enforcing cGroup-specific policies.
 
 ### Program types
 
@@ -52,5 +51,16 @@ This helper call can be used in the following program types:
 
 ### Example
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+```c
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
+SEC("lsm_cgroup/inode_create")
+int BPF_PROG(lsm_pre_bpf_file) {
+    __u64 cgroup_id = bpf_get_current_cgroup_id();
+    if (cgroup_id == 12092) {
+        bpf_printk("Task from the target cgroup has created an inode!\n");
+    }
+    return 0;
+}
+```

--- a/docs/linux/helper-function/bpf_get_current_comm.md
+++ b/docs/linux/helper-function/bpf_get_current_comm.md
@@ -25,8 +25,7 @@ Copy the **comm** attribute of the current task into _buf_ of _size_of_buf_. The
 
 ## Usage
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+The `bpf_get_current_comm` helper function retrieves the name of the executable associated with the current task. This is useful for identifying the process context in which the eBPF program is executing, enabling per-process tracing. It can help trace specific applications, enforce process-level policies, or monitor system behavior tied to particular commands.
 
 ### Program types
 

--- a/docs/linux/helper-function/bpf_get_current_pid_tgid.md
+++ b/docs/linux/helper-function/bpf_get_current_pid_tgid.md
@@ -25,8 +25,7 @@ A 64-bit integer containing the current tgid and pid, and created as such: _curr
 
 ## Usage
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+The `bpf_get_current_pid_tgid` helper function returns a 64-bit value containing the current task's PID in the lower 32 bits and TGID (thread group ID) in the upper 32 bits. This helper allows eBPF programs to identify the process and its thread group, which is useful for tracking individual threads or entire processes, enforcing thread-specific policies.
 
 ### Program types
 
@@ -68,5 +67,16 @@ This helper call can be used in the following program types:
 
 ### Example
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+```c
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
+SEC("tp/syscalls/sys_enter_open")
+int sys_open_trace(void *ctx) {
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 pid = pid_tgid >> 32;
+	__u32 tgid = pid_tgid & 0xFFFFFFFF;
+    bpf_printk("Hello from PID %u, TGID %u\n", pid, tgid);
+    return 0;
+}
+```

--- a/docs/linux/helper-function/bpf_get_current_uid_gid.md
+++ b/docs/linux/helper-function/bpf_get_current_uid_gid.md
@@ -25,8 +25,7 @@ A 64-bit integer containing the current GID and UID, and created as such: _curre
 
 ## Usage
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+The `bpf_get_current_uid_gid` helper function returns a 64-bit value containing the current task's UID in the lower 32 bits and GID in the upper 32 bits. This allows eBPF programs to identify the user and group context of the running task. It is useful for enforcing security policies, tracking actions by specific users or groups, and implementing per-UID or per-GID tracing.
 
 ### Program types
 
@@ -52,5 +51,17 @@ This helper call can be used in the following program types:
 
 ### Example
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+
+```c
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
+SEC("tp/syscalls/sys_enter_open")
+int sys_open_trace(void *ctx) {
+    __u64 uid_gid = bpf_get_current_uid_gid();
+    __u32 uid = uid_gid >> 32;
+    __u32 gid = uid_gid & 0xFFFFFFFF;
+    bpf_printk("Hello from UID %u, GID %u\n", uid, gid);
+    return 0;
+}
+```


### PR DESCRIPTION
Add usage examples for bpf_get_current_cgroup_id, bpf_get_current_comm, bpf_get_current_uid_gid and bpf_get_current_pid_tgid