### PR TITLE
libbpf/ebpf: Add example to `PT_REGS_SYSCALL_REGS`

### DIFF
--- a/docs/ebpf-library/libbpf/ebpf/PT_REGS_PARM_SYSCALL.md
+++ b/docs/ebpf-library/libbpf/ebpf/PT_REGS_PARM_SYSCALL.md
@@ -1,0 +1,43 @@
+---
+title: "Libbpf eBPF macro 'PT_REGS_PARM_SYSCALL'"
+description: "This page documents the 'PT_REGS_PARM_SYSCALL' libbpf eBPF macro, including its definition, usage, and examples."
+---
+# Libbpf eBPF macro `PT_REGS_PARM_SYSCALL`
+
+[:octicons-tag-24: v0.7.0](https://github.com/libbpf/libbpf/releases/tag/v0.7.0)
+
+The `PT_REGS_PARM{1-8}_SYSCALL` macros make it easy to extract an argument from `struct pt_regs` following the syscall calling convention in an architecture-independent way.
+
+## Usage
+
+These macro are variants of the [`PT_REGS_PARAM{1-8}`](PT_REGS_PARM.md) macros that translate a parameter number to the correct register according to the syscall calling convention, which can be different from the normal calling convention. So when reading arguments to a syscall, these should be used.
+
+The architecture for which the eBPF program is compiled is determined by setting one of the `__TARGET_ARCH_{arch}` macros. These are typically set by passing a flag to the compiler, such as `-D__TARGET_ARCH_x86` for x86. This allows for easy cross-compilation of eBPF programs for different architectures by changing the compiler invocation.
+
+### Example
+
+```c hl_lines="10 11"
+// SPDX-License-Identifier: GPL-2.0
+
+/*
+ * Copyright 2020 Google LLC.
+ */
+
+SEC("fentry.s/" SYS_PREFIX "sys_setdomainname")
+int [BPF_PROG](BPF_PROG.md)(test_sys_setdomainname, struct pt_regs *regs)
+{
+	void *ptr = (void *)PT_REGS_PARM1_SYSCALL(regs);
+	int len = PT_REGS_PARM2_SYSCALL(regs);
+	int buf = 0;
+	long ret;
+
+	ret = [bpf_copy_from_user](../../../linux/helper-function/bpf_copy_from_user.md)(&buf, sizeof(buf), ptr);
+	if (len == -2 && ret == 0 && buf == 1234)
+		copy_test++;
+	if (len == -3 && ret == -EFAULT)
+		copy_test++;
+	if (len == -4 && ret == -EFAULT)
+		copy_test++;
+	return 0;
+}
+```

--- a/docs/ebpf-library/libbpf/ebpf/PT_REGS_SYSCALL_REGS.md
+++ b/docs/ebpf-library/libbpf/ebpf/PT_REGS_SYSCALL_REGS.md
@@ -17,13 +17,37 @@ The `PT_REGS_SYSCALL_REGS` macro that ensures consistent access to `struct pt_re
 
 ### Usage
 
-This macro is useful when placing kprobes on syscalls. On some CPU architectures the kernel will use a so called syscall wrapper (indicated by the `CONFIG_ARCH_HAS_SYSCALL_WRAPPER` kernel config). These wrappers change the syscall calling convention, so the actual `struct pt_regs` are in a different location then normally expected.
+This macro is useful when placing kprobes on syscalls. On some CPU architectures the kernel will use a so called syscall wrapper (indicated by the `CONFIG_ARCH_HAS_SYSCALL_WRAPPER` kernel config). The syscall calling convention (which registers are used for what parameter) can differ from the normal calling convention. A syscall wrapper translates syscall calling convention to normal calling convention before invoking the actual syscall function.
 
-This macro corrects for this based on the target architecture and returns the expected `struct pt_regs`.
+You might need to attach to this wrapper since the function that is called once in the right calling convention might be inlined. The wrapper is handed a `struct pt_regs *` as its first argument by the syscall interrupt handler, which contains the values passed by userspace. When a kprobe executes it also causes an interrupt yielding a second `struct pt_regs *` with the registers as the wrapper gets them.
+
+```
+kprobe arg1 -> pt_regs (wrapper) arg1 -> pt_regs (syscall)
+```
+
+Since its likely the syscall arguments that are of interest we need to unwrap. Which is what `PT_REGS_SYSCALL_REGS` does. You give it the kprobe `struct pt_regs *` and it returns the syscall `struct pt_regs *`.
 
 The architecture for which the eBPF program is compiled is determined by setting one of the `__TARGET_ARCH_{arch}` macros. These are typically set by passing a flag to the compiler, such as `-D__TARGET_ARCH_x86` for x86. This allows for easy cross-compilation of eBPF programs for different architectures by changing the compiler invocation.
 
 ### Example
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+This example places a kprobe on the open syscall wrapper. We get the syscall registers with `PT_REGS_SYSCALL_REGS`.
+In order to access the second parameter of the syscall we need to probe the syscall `struct pt_regs *`. We use the [`PT_REGS_PARM2_SYSCALL`](PT_REGS_PARM_SYSCALL.md) macro to get the correct register for param 2 according to the syscall calling convention.
+
+```c hl_lines="4"
+SEC("kprobe/" SYS_PREFIX "open")
+int trace_sys_open(struct pt_regs *ctx)
+{
+    struct pt_regs *realregs = PT_REGS_SYSCALL_REGS(ctx);
+    
+    int flags;
+    [bpf_probe_read_kernel](../../../linux/helper-function/bpf_probe_read_kernel.md)(&flags, sizeof(flags), &[PT_REGS_PARM2_SYSCALL](PT_REGS_PARM_SYSCALL.md)(realregs));
+    if (flags & O_CREAT) {
+        bpf_printk("Creating a file");
+    }
+
+    return 0;
+}
+```
+
+

--- a/docs/ebpf-library/libbpf/ebpf/SUMMARY.md
+++ b/docs/ebpf-library/libbpf/ebpf/SUMMARY.md
@@ -45,6 +45,7 @@
 - [`bpf_cpu_to_be64`](bpf_cpu_to_be64.md)
 - [`bpf_be64_to_cpu`](bpf_be64_to_cpu.md)
 - [`PT_REGS_PARM`](PT_REGS_PARM.md)
+- [`PT_REGS_PARM_SYSCALL`](PT_REGS_PARM_SYSCALL.md)
 - [`PT_REGS_RET`](PT_REGS_RET.md)
 - [`PT_REGS_FP`](PT_REGS_FP.md)
 - [`PT_REGS_RC`](PT_REGS_RC.md)

--- a/docs/ebpf-library/libbpf/ebpf/index.md
+++ b/docs/ebpf-library/libbpf/ebpf/index.md
@@ -88,6 +88,7 @@ The `bpf_tracing.h` file contains macros which are mostly meant for tracing-like
 The file contains definitions for the following:
 
 * [`PT_REGS_PARM`](PT_REGS_PARM.md)
+* [`PT_REGS_PARM_SYSCALL`](PT_REGS_PARM_SYSCALL.md)
 * [`PT_REGS_RET`](PT_REGS_RET.md)
 * [`PT_REGS_FP`](PT_REGS_FP.md)
 * [`PT_REGS_RC`](PT_REGS_RC.md)


### PR DESCRIPTION
Added an example to the `PT_REGS_SYSCALL_REGS` documentation. Also improve the usage section of that page a bit.

Discovered the page for `PT_REGS_PARM_SYSCALL` was missing, so I added that as well.