### PR TITLE
bpf_get_current_* helpers: Fix reversed order of PID/TGID and UID/GID extraction

### DIFF
--- a/docs/linux/helper-function/bpf_get_current_pid_tgid.md
+++ b/docs/linux/helper-function/bpf_get_current_pid_tgid.md
@@ -74,8 +74,8 @@ This helper call can be used in the following program types:
 SEC("tp/syscalls/sys_enter_open")
 int sys_open_trace(void *ctx) {
     __u64 pid_tgid = bpf_get_current_pid_tgid();
-    __u32 pid = pid_tgid >> 32;
-	__u32 tgid = pid_tgid & 0xFFFFFFFF;
+    __u32 pid = pid_tgid & 0xFFFFFFFF;
+    __u32 tgid = pid_tgid >> 32;
     bpf_printk("Hello from PID %u, TGID %u\n", pid, tgid);
     return 0;
 }

--- a/docs/linux/helper-function/bpf_get_current_uid_gid.md
+++ b/docs/linux/helper-function/bpf_get_current_uid_gid.md
@@ -59,8 +59,8 @@ This helper call can be used in the following program types:
 SEC("tp/syscalls/sys_enter_open")
 int sys_open_trace(void *ctx) {
     __u64 uid_gid = bpf_get_current_uid_gid();
-    __u32 uid = uid_gid >> 32;
-    __u32 gid = uid_gid & 0xFFFFFFFF;
+    __u32 uid = uid_gid & 0xFFFFFFFF;
+    __u32 gid = uid_gid >> 32;
     bpf_printk("Hello from UID %u, GID %u\n", uid, gid);
     return 0;
 }


### PR DESCRIPTION
This PR resolves issue #180 by correcting the extraction order for both `bpf_get_current_pid_tgid()` and `bpf_get_current_uid_gid()`. In the existing documentation, the code mistakenly reads the PID and TGID from the wrong 32-bit halves of the 64-bit return value. While investigating that issue, it was discovered that the same reversal also affects the `bpf_get_current_uid_gid()` helper.

**Changes included**

* Swap the high- and low-word interpretations for `bpf_get_current_pid_tgid()` so that TGID is extracted from the upper 32 bits and PID from the lower 32 bits.
* Apply the equivalent correction to `bpf_get_current_uid_gid()`, ensuring that GID is taken from the upper 32 bits and UID from the lower 32 bits.

**References**

* [bpf\_get\_current\_pid\_tgid in Linux kernel](https://github.com/torvalds/linux/blob/1af80d00e1e026c317c6ec19b1072f81ba7af64c/kernel/bpf/helpers.c#L224)
* [bpf\_get\_current\_uid\_gid in Linux kernel](https://github.com/torvalds/linux/blob/1af80d00e1e026c317c6ec19b1072f81ba7af64c/kernel/bpf/helpers.c#L240)

