### PR TITLE
Fix minor issues in `bpf_obj_get_info_by_fd` documentation

### DIFF
--- a/docs/ebpf-library/libbpf/userspace/bpf_obj_get_info_by_fd.md
+++ b/docs/ebpf-library/libbpf/userspace/bpf_obj_get_info_by_fd.md
@@ -18,11 +18,11 @@ Low level wrapper around the [`BPF_OBJ_GET_INFO_BY_FD`](../../../linux/syscall/B
 
 - `bpf_fd`: file descriptor of the BPF object
 - `info`: buffer to store the information about the BPF object
-- `info_len`: size of the `info` buffer
+- `info_len`: indicates the size of the buffer which `info` points to and will be changed by the syscall command to the actual amount of data written to the `info` buffer
 
 **Return**
 
-`>0`, amount of information written to the `info` buffer; negative error code, otherwise
+`0`, on success; negative error code, otherwise
 
 ## Usage
 


### PR DESCRIPTION
This patch corrects minor inaccuracies in the `bpf_obj_get_info_by_fd` documentation regarding `info_len` and the return value descriptions.

1. Clarifies that `info_len` acts as both input *and* output, with the syscall updating it to reflect the actual written data.
2. Fixes the return value description to match the implementation: `0` on success, negative error code on failure.

Changes are based on [`BPF_OBJ_GET_INFO_BY_FD`](https://docs.ebpf.io/linux/syscall/BPF_OBJ_GET_INFO_BY_FD/) and aligns with `libbpf` implementation in [`src/bpf.c:1144`](https://github.com/libbpf/libbpf/blob/master/src/bpf.c#L1144) and
here is a brief part of the implementation:
```c
int bpf_obj_get_info_by_fd(int bpf_fd, void *info, __u32 *info_len)
{
    // ....
    attr.info.info_len = *info_len;
    // ....
    if (!err)
        *info_len = attr.info.info_len;
    return libbpf_err_errno(err);
}
```

Hope it helps a little
Thanks :)