### PR TITLE
An example for `bpf_xdp_adjust_head`

### DIFF
--- a/docs/linux/helper-function/bpf_xdp_adjust_head.md
+++ b/docs/linux/helper-function/bpf_xdp_adjust_head.md
@@ -41,5 +41,54 @@ This helper call can be used in the following program types:
 
 ### Example
 
-!!! example "Docs could be improved"
-    This part of the docs is incomplete, contributions are very welcome
+This example, inspired by the Linux kernel's [`tools/testing/selftests/bpf/progs/test_xdp_vlan.c`][test_exdp_vlan.c]
+demonstrates how to remove an outer `802.1q` VLAN tag (_4 bytes_) from Ethernet packets.
+The program shifts the Ethernet header to overwrite the VLAN tag and adjusts the packet size using `bpf_xdp_adjust_head`.
+
+[test_exdp_vlan.c]: https://elixir.bootlin.com/linux/v6.15/source/tools/testing/selftests/bpf/progs/test_xdp_vlan.c#L182
+
+```c
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <bpf/bpf_helpers.h>
+
+#define VLAN_HDR_SZ (4)
+
+SEC("xdp")
+int xdp_remove_outer_vlan_tag(struct xdp_md *ctx)
+{
+    void *data = (void *)(long)ctx->data;
+    void *data_end = (void *)(long)ctx->data_end;
+    struct ethhdr *eth = data;
+
+    /* Ensure there's enough room for (ethernet + vlan) headers */
+    int hdrsize = (sizeof(struct ethhdr) + VLAN_HDR_SZ);
+    if ((data + hdrsize > data_end) || (eth->h_proto != bpf_htons(ETH_P_8021Q))) {
+        return XDP_PASS;
+    }
+
+     /*
+     * To remove the VLAN header, shift the source and
+     * destination MAC addresses (12 bytes) right by VLAN_HDR_SZ (4 bytes),
+     * overwriting the VLAN's TPID and TCI fields.
+     * The encapsulated protocol remains unchanged.
+     *
+     * Since *dest* and *data* overlap, *__builtin_memmove*
+     * ensures safe copying. Alternatively, you could save the MAC
+     * addresses and restore them after shrinking the packet.
+     */
+    char *dest = (data + VLAN_HDR_SZ);
+    __builtin_memmove(dest, data, ETH_ALEN * 2);
+
+    /* Shrink packet by VLAN header size */
+    bpf_xdp_adjust_head(ctx, VLAN_HDR_SZ);
+
+    /*
+     * Note: After bpf_xdp_adjust_head, the eBPF verifier invalidates all
+     * previous pointer checks. Any subsequent pointer accesses (e.g., to data
+     * or eth) must be revalidated to ensure safety.
+     */
+
+    return XDP_PASS;
+}
+```


### PR DESCRIPTION
Simple example based on [test_xdp_vlan.c](https://elixir.bootlin.com/linux/v6.15/source/tools/testing/selftests/bpf/progs/test_xdp_vlan.c#L182) to showcase `bpf_xdp_adjust_head` usage.


Hope it's useful
Thanks :)