### PR TITLE
Update BPF_MAP_TYPE_RINGBUF.md

### DIFF
--- a/docs/linux/map-type/BPF_MAP_TYPE_RINGBUF.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_RINGBUF.md
@@ -10,7 +10,7 @@ description: "This page documents the 'BPF_MAP_TYPE_RINGBUF' eBPF map type, incl
 
 The ring-buffer map can be used to efficiently send large amounts of data from eBPF programs to userspace. Data is sent in a queue / first-in-first-out (FIFO) manner.
 
-This map consists of a singular ring as opposed to the per-CPU design of the `BPF_MAP_TYPE_PERF_ARRAY` map type. This means that the order of events is preserved across all CPUs.
+This map consists of a singular ring as opposed to the per-CPU design of the `BPF_MAP_TYPE_PERF_EVENT_ARRAY` map type. This means that the order of events is preserved across all CPUs.
 
 ## Attributes
 


### PR DESCRIPTION
Corrected `BPF_MAP_TYPE_PERF_ARRAY` to `BPF_MAP_TYPE_PERF_EVENT_ARRAY`.

Looking around I can find discussions about this map type beeing called `BPF_MAP_TYPE_PERF_ARRAY`, but checking the [definition in the kernel](https://github.com/torvalds/linux/blob/89be9a83ccf1f88522317ce02f854f30d6115c41/include/uapi/linux/bpf.h#L972C2-L972C31) it has event in the name, so this patch changes it for consistency with the rest of the documentation