### PR TITLE
helper-functions: add get_netns_cookie support for cgroup_skb progs

### DIFF
--- a/data/helpers-functions.yaml
+++ b/data/helpers-functions.yaml
@@ -245,6 +245,10 @@ groups:
   - name: bpf_skb_load_bytes
   - name: bpf_skb_load_bytes_relative
   - name: bpf_get_socket_cookie
+  - name: bpf_get_netns_cookie
+    since:
+      version: 6.15
+      commit: c221d3744ad38a9655aba8235e1d783c6d4aed5a
   - name: bpf_get_socket_uid
   - name: bpf_perf_event_output
   - group: base

--- a/docs/linux/helper-function/bpf_get_netns_cookie.md
+++ b/docs/linux/helper-function/bpf_get_netns_cookie.md
@@ -34,12 +34,14 @@ This helper call can be used in the following program types:
 
 <!-- DO NOT EDIT MANUALLY -->
 <!-- [HELPER_FUNC_PROG_REF] -->
+ * [`BPF_PROG_TYPE_CGROUP_SKB`](../program-type/BPF_PROG_TYPE_CGROUP_SKB.md) [:octicons-tag-24: v6.15](https://github.com/torvalds/linux/commit/c221d3744ad38a9655aba8235e1d783c6d4aed5a)
  * [`BPF_PROG_TYPE_CGROUP_SOCK`](../program-type/BPF_PROG_TYPE_CGROUP_SOCK.md)
  * [`BPF_PROG_TYPE_CGROUP_SOCKOPT`](../program-type/BPF_PROG_TYPE_CGROUP_SOCKOPT.md)
  * [`BPF_PROG_TYPE_CGROUP_SOCK_ADDR`](../program-type/BPF_PROG_TYPE_CGROUP_SOCK_ADDR.md)
  * [`BPF_PROG_TYPE_SCHED_ACT`](../program-type/BPF_PROG_TYPE_SCHED_ACT.md) [:octicons-tag-24: v6.13](https://github.com/torvalds/linux/commit/eb62f49de7eca5917be8cebb3ad8aa3710af7021)
  * [`BPF_PROG_TYPE_SCHED_CLS`](../program-type/BPF_PROG_TYPE_SCHED_CLS.md) [:octicons-tag-24: v6.13](https://github.com/torvalds/linux/commit/eb62f49de7eca5917be8cebb3ad8aa3710af7021)
  * [`BPF_PROG_TYPE_SK_MSG`](../program-type/BPF_PROG_TYPE_SK_MSG.md)
+ * [`BPF_PROG_TYPE_SOCKET_FILTER`](../program-type/BPF_PROG_TYPE_SOCKET_FILTER.md) [:octicons-tag-24: v6.15](https://github.com/torvalds/linux/commit/c221d3744ad38a9655aba8235e1d783c6d4aed5a)
  * [`BPF_PROG_TYPE_SOCK_OPS`](../program-type/BPF_PROG_TYPE_SOCK_OPS.md)
 <!-- [/HELPER_FUNC_PROG_REF] -->
 

--- a/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SKB.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_CGROUP_SKB.md
@@ -262,6 +262,7 @@ char _license[] SEC("license") = "GPL";
     * [`bpf_get_current_task_btf`](../helper-function/bpf_get_current_task_btf.md)
     * [`bpf_get_listener_sock`](../helper-function/bpf_get_listener_sock.md)
     * [`bpf_get_local_storage`](../helper-function/bpf_get_local_storage.md)
+    * [`bpf_get_netns_cookie`](../helper-function/bpf_get_netns_cookie.md) [:octicons-tag-24: v6.15](https://github.com/torvalds/linux/commit/c221d3744ad38a9655aba8235e1d783c6d4aed5a)
     * [`bpf_get_ns_current_pid_tgid`](../helper-function/bpf_get_ns_current_pid_tgid.md) [:octicons-tag-24: v6.10](https://github.com/torvalds/linux/commit/eb166e522c77699fc19bfa705652327a1e51a117)
     * [`bpf_get_numa_node_id`](../helper-function/bpf_get_numa_node_id.md)
     * [`bpf_get_prandom_u32`](../helper-function/bpf_get_prandom_u32.md)

--- a/docs/linux/program-type/BPF_PROG_TYPE_SOCKET_FILTER.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_SOCKET_FILTER.md
@@ -84,6 +84,7 @@ Not all helper functions are available in all program types. These are the helpe
     * [`bpf_get_current_pid_tgid`](../helper-function/bpf_get_current_pid_tgid.md) [:octicons-tag-24: v6.10](https://github.com/torvalds/linux/commit/eb166e522c77699fc19bfa705652327a1e51a117)
     * [`bpf_get_current_task`](../helper-function/bpf_get_current_task.md)
     * [`bpf_get_current_task_btf`](../helper-function/bpf_get_current_task_btf.md)
+    * [`bpf_get_netns_cookie`](../helper-function/bpf_get_netns_cookie.md) [:octicons-tag-24: v6.15](https://github.com/torvalds/linux/commit/c221d3744ad38a9655aba8235e1d783c6d4aed5a)
     * [`bpf_get_ns_current_pid_tgid`](../helper-function/bpf_get_ns_current_pid_tgid.md) [:octicons-tag-24: v6.10](https://github.com/torvalds/linux/commit/eb166e522c77699fc19bfa705652327a1e51a117)
     * [`bpf_get_numa_node_id`](../helper-function/bpf_get_numa_node_id.md)
     * [`bpf_get_prandom_u32`](../helper-function/bpf_get_prandom_u32.md)


### PR DESCRIPTION
This was added in the sk_filter_func_proto function so it affects sk_filter and cgroup_skb progs.