### PR TITLE
libbpf/userspace: Add notes to map functions about name clash

### DIFF
--- a/docs/ebpf-library/libbpf/userspace/bpf_map_delete_elem.md
+++ b/docs/ebpf-library/libbpf/userspace/bpf_map_delete_elem.md
@@ -10,6 +10,9 @@ description: "This page documents the 'bpf_map_delete_elem' libbpf userspace fun
 
 Low level wrapper around the [`BPF_MAP_DELETE_ELEM`](../../../linux/syscall/BPF_MAP_DELETE_ELEM.md) syscall command.
 
+!!! note
+    This function is part of the libbpf userspace library, but has the same name as the [`bpf_map_delete_elem`](../../../linux/helper-function/bpf_map_delete_elem.md) helper function, which can only be used from an eBPF program.
+
 ## Definition
 
 `#!c int bpf_map_delete_elem(int fd, const void *key);`

--- a/docs/ebpf-library/libbpf/userspace/bpf_map_lookup_elem.md
+++ b/docs/ebpf-library/libbpf/userspace/bpf_map_lookup_elem.md
@@ -10,6 +10,9 @@ description: "This page documents the 'bpf_map_lookup_elem' libbpf userspace fun
 
 Low level wrapper around the [`BPF_MAP_LOOKUP_ELEM`](../../../linux/syscall/BPF_MAP_LOOKUP_ELEM.md) syscall command.
 
+!!! note
+    This function is part of the libbpf userspace library, but has the same name as the [`bpf_map_lookup_elem`](../../../linux/helper-function/bpf_map_lookup_elem.md) helper function, which can only be used from an eBPF program.
+
 ## Definition
 
 `#!c int bpf_map_lookup_elem(int fd, const void *key, void *value);`

--- a/docs/ebpf-library/libbpf/userspace/bpf_map_update_elem.md
+++ b/docs/ebpf-library/libbpf/userspace/bpf_map_update_elem.md
@@ -10,6 +10,9 @@ description: "This page documents the 'bpf_map_update_elem' libbpf userspace fun
 
 Low level wrapper around the [`BPF_MAP_UPDATE_ELEM`](../../../linux/syscall/BPF_MAP_UPDATE_ELEM.md) syscall command.
 
+!!! note
+    This function is part of the libbpf userspace library, but has the same name as the [`bpf_map_update_elem`](../../../linux/helper-function/bpf_map_update_elem.md) helper function, which can only be used from an eBPF program.
+
 ## Definition
 
 `#!c int bpf_map_update_elem(int fd, const void *key, const void *value, __u64 flags);`

--- a/docs/linux/helper-function/bpf_map_delete_elem.md
+++ b/docs/linux/helper-function/bpf_map_delete_elem.md
@@ -10,6 +10,9 @@ description: "This page documents the 'bpf_map_delete_elem' eBPF helper function
 
 The delete map element helper call is used to delete values from [maps](../index.md#maps).
 
+!!! note
+    This helper function is only callable from eBPF, but has the same name as the [`bpf_map_delete_elem`](../../ebpf-library/libbpf/userspace/bpf_map_delete_elem.md) userspace library function, which can only be used from userspace programs.
+
 ## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.

--- a/docs/linux/helper-function/bpf_map_lookup_elem.md
+++ b/docs/linux/helper-function/bpf_map_lookup_elem.md
@@ -10,6 +10,9 @@ description: "This page documents the 'bpf_map_lookup_elem' eBPF helper function
 
 The lookup map element helper call is used to read values from [maps](../index.md#maps).
 
+!!! note
+    This helper function is only callable from eBPF, but has the same name as the [`bpf_map_lookup_elem`](../../ebpf-library/libbpf/userspace/bpf_map_lookup_elem.md) userspace library function, which can only be used from userspace programs.
+
 ## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.

--- a/docs/linux/helper-function/bpf_map_update_elem.md
+++ b/docs/linux/helper-function/bpf_map_update_elem.md
@@ -10,6 +10,9 @@ description: "This page documents the 'bpf_map_update_elem' eBPF helper function
 
 The update map element helper call is used to write values from [maps](../index.md#maps).
 
+!!! note
+    This helper function is only callable from eBPF, but has the same name as the [`bpf_map_update_elem`](../../ebpf-library/libbpf/userspace/bpf_map_update_elem.md) userspace library function, which can only be used from userspace programs.
+
 ## Definition
 
 > Copyright (c) 2015 The Libbpf Authors. All rights reserved.


### PR DESCRIPTION
Libbpf uses the same names for some of its map functions as the helper functions available in eBPF programs. This can lead to confusion when reading documentation if you arrived there via search or a link.

Hopefully these notes will help clarify the difference.

Fixes: #210 