### PR TITLE
Fix wrong statement saying devmap_hash keys can have any size.

### DIFF
--- a/docs/linux/map-type/BPF_MAP_TYPE_DEVMAP_HASH.md
+++ b/docs/linux/map-type/BPF_MAP_TYPE_DEVMAP_HASH.md
@@ -35,7 +35,7 @@ The `fd`/`id` refers to an XDP program optionally set by userspace. If set, the 
 
 ## Attributes
 
-The [`value_size`](../syscall/BPF_MAP_CREATE.md#value_size) can be `4` or `8` depending on kernel version and optional secondary program support. The [`key_size`](../syscall/BPF_MAP_CREATE.md#key_size) can be freely chosen.
+The [`value_size`](../syscall/BPF_MAP_CREATE.md#value_size) can be `4` or `8` depending on kernel version and optional secondary program support. The [`key_size`](../syscall/BPF_MAP_CREATE.md#key_size) must always be `4`.
 
 <!-- TODO link to generic page for attributes which are the same for every map type -->
 


### PR DESCRIPTION
Hi,

Following this documentation, that was stating that the key_size for BPF_MAP_TYPE_DEVMAP_HASH could be freely chosen ([ref](https://github.com/isovalent/ebpf-docs/blob/af699890f121750ebff920636d270132008aa032/docs/linux/map-type/BPF_MAP_TYPE_DEVMAP_HASH.md?plain=1#L38)) I've been trying to create a map of this kind with a key size of 8, always getting an EINVAL error.

After some debugging, I've found that the mainline kernel enforces a key_size of 4 for any kind of devmap, regardless of whether is a devmap or a devmap_hash ([ref](https://github.com/torvalds/linux/blob/5d6919055dec134de3c40167a490f33c74c12581/kernel/bpf/devmap.c#L119)), which contradicts the current docs. This PR does that fix by explicitly stating that a devmap_hash must have a key size of 4.

I'm not an experienced eBPF developer, but after doing some debugging and some testing changing the values of key_size for my map, I couldn't find any other conclusion except that the docs were incorrect in this regard. Any feedback is appreciated.

I'm also leaving here the the eBPF program whose map I was unable to create, for reference:

```c
struct {
    __uint(type, BPF_MAP_TYPE_DEVMAP_HASH);
    __type(key, __u64);
    __type(value, __u32);
    __uint(max_entries, 128);
} mac_tx_port SEC(".maps");

SEC("xdp")
int xdp_test(struct xdp_md *ctx)
{
    return XDP_PASS;
}

char _license[] SEC("license") = "GPL";
``` 

