### PR TITLE
libxdp/functions: Remove incorrect note regarding xsk_ring_prod_reserve

### DIFF
--- a/docs/ebpf-library/libxdp/functions/xsk_ring_prod__reserve.md
+++ b/docs/ebpf-library/libxdp/functions/xsk_ring_prod__reserve.md
@@ -12,9 +12,6 @@ Reserve one or more slots in a **producer** ring.
 
 `__u32` number of slots that were successfully reserved (`idx`) on success, or a 0 in case of failure.
 
-!!! note
-    It can be less than or equal to the number of packets requested to reserve.
-
 ## Usage
 
 ```c


### PR DESCRIPTION
The 'note' states that xsk_ring_prod_reserve may reserve packets "less than or equal to" that which was requested. This is incorrect since the function only reserves the requested number of packets (if possible) or none at all, rather than a number in between.