### PR TITLE
Correct typo (to -> too)

### DIFF
--- a/docs/linux/program-context/__sk_buff.md
+++ b/docs/linux/program-context/__sk_buff.md
@@ -180,7 +180,7 @@ This field is a pointer to a `struct bpf_flow_keys` which like the name implies 
 This field indicates the time when this packet should be transmitted in nanoseconds since boot. [`BPF_PROG_TYPE_SCHED_CLS`](../program-type/BPF_PROG_TYPE_SCHED_CLS.md) programs can set this time to some time in the future to add delay to packets for the purposes of bandwidth limiting or simulating latency. Setting this value only works on egress if the `fq` (Fair Queue) qdisc is used.
 
 !!! note
-    The `fq` qdisc has a "drop horizon" if packets are set to transmit to far into the future they will be dropped to avoid queueing to many packets.
+    The `fq` qdisc has a "drop horizon" if packets are set to transmit to far into the future they will be dropped to avoid queueing too many packets.
 
 !!! note
     After v5.18 [1](https://github.com/torvalds/linux/commit/8d21ec0e46ed6e39994accff8eb4f2be3d2e76b5) / [2](https://github.com/torvalds/linux/commit/9bb984f28d5bcb917d35d930fcfb89f90f9449fd) the meaning of this field can also be "received time" and the [`tstamp_type`](#tstamp_type) field will indicate one or the other.


### PR DESCRIPTION
As the title and code change suggests, this PR corrects a very small grammatical error.