### PR TITLE
Fixed a duplicate in struct_ops SUMMARY.md and a mistake in sched_ext_ops.md

### DIFF
--- a/docs/linux/program-type/BPF_PROG_TYPE_STRUCT_OPS/sched_ext_ops.md
+++ b/docs/linux/program-type/BPF_PROG_TYPE_STRUCT_OPS/sched_ext_ops.md
@@ -300,9 +300,7 @@ A task is becoming not runnable on its associated CPU. See [`runnable`](#runnabl
 * being moved to another CPU
 * being temporarily taken off the queue for an attribute change (`SCX_DEQ_SAVE`).
 
-* This and [`dequeue`](#dequeue) are related but not coupled. This operation
-* notifies `p`'s state transition and may not be preceded by [`dequeue`](#dequeue)
-* e.g. when `p` is being dispatched to a remote CPU.
+This and [`dequeue`](#dequeue) are related but not coupled. This operation notifies `p`'s state transition and may not be preceded by [`dequeue`](#dequeue) e.g. when `p` is being dispatched to a remote CPU.
 
 **Parameters**
 

--- a/docs/linux/program-type/SUMMARY.md
+++ b/docs/linux/program-type/SUMMARY.md
@@ -38,5 +38,5 @@
   * [`struct hid_bpf_ops`](BPF_PROG_TYPE_STRUCT_OPS/hid_bpf_ops.md)
   * [`struct sched_ext_ops`](BPF_PROG_TYPE_STRUCT_OPS/sched_ext_ops.md)
   * [`struct Qdisc_ops`](BPF_PROG_TYPE_STRUCT_OPS/Qdisc_ops.md)
-  * [`struct sched_ext_ops`](BPF_PROG_TYPE_STRUCT_OPS/sched_ext_ops.md)
+  * [`struct smc_hs_ctrl`](BPF_PROG_TYPE_STRUCT_OPS/smc_hs_ctrl.md)
 * [`BPF_PROG_TYPE_SYSCALL`](BPF_PROG_TYPE_SYSCALL.md)


### PR DESCRIPTION
A previous commit created the page smc_hs_ctrl but created a second entry for sched_ext_ops in the summary. I assumed a link to smc_hs_ctrl was intended to be created so I fixed it.
Additionally a paragraph in the quiescent section of sched_ext_ops.md was split mid-sentence by several bullet points so I fixed it as well. 