### PR TITLE
Simplify IP header size checks in loops documentation and corrected p…

### DIFF
--- a/docs/linux/concepts/loops.md
+++ b/docs/linux/concepts/loops.md
@@ -30,9 +30,6 @@ struct iphdr *ip = data + sizeof(struct ethhdr);
 if (ip + sizeof(struct iphdr) > data_end)
     return XDP_DROP;
 
-if (ip + sizeof(struct iphdr) > data_end)
-    return XDP_DROP;
-
 for (int i = 0; i < ip->tot_len; i++) {
     // scan IP body for something
 }
@@ -44,9 +41,6 @@ Since `ip->tot_len` is a 16 bit integer, the verifier will check the body for ev
 void *data = ctx->data;
 void *data_end = ctx->data_end;
 struct iphdr *ip = data + sizeof(struct ethhdr);
-if (ip + sizeof(struct iphdr) > data_end)
-    return XDP_DROP;
-
 if (ip + sizeof(struct iphdr) > data_end)
     return XDP_DROP;
 
@@ -69,7 +63,7 @@ Sometimes you really need to iterate over a huge range. For cases where any of t
 
 ## Numeric open coded iterators
 
-In [:octicons-tag-24: v6.4](https://github.com/torvalds/linux/commit/06accc8779c1d558a5b5a21f2ac82b0c95827ddd) open-coded iterators were introduced. Which allow programs to iterate over kernel objects. The numeric iterator allows us to iterate over a range of numbers, allowing us to make a for loop.
+In [:octicons-tag-24: v6.4](https://github.com/torvalds/linux/commit/06accc8779c1d558a5b5a21f2ac82b0c95827ddd) open-coded iterators were introduced, which allow programs to iterate over kernel objects. The numeric iterator allows us to iterate over a range of numbers, allowing us to make a for loop.
 
 The advantage of this method is that the verifier only has to check two states as opposed to the amount of iterations like with a bounded loop and we don't require a callback function like with the loop helper.
 


### PR DESCRIPTION
…unctuation

Removed redundant checks for IP header size in loops example section. Replaced incorrect full stop with comma after "Open-coded iterators were introduced"